### PR TITLE
fix: lower SDK constraint to support Dart 3.5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # Changelog
 
+## [0.2.4] - 2025-10-27
+
+### Fixed
+- **SDK Constraint**: Lowered minimum Dart SDK requirement from 3.8.0 to 3.5.0
+  - Resolves installation issues for users with Dart SDK 3.5.x - 3.7.x
+  - Ensures compatibility with Flutter 3.35.7 and similar versions
+  - Previously published versions (0.1.1 - 0.2.3) required unavailable Dart 3.8.0
+
 ## [0.2.3] - 2025-10-27
 
 ### Changed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: notion_dart_kit
 description: A comprehensive, type-safe Dart toolkit for the Notion API. Full endpoint coverage, built-in rate limiting, retry logic, and intuitive query DSL for Dart & Flutter.
-version: 0.2.3
+version: 0.2.4
 homepage: https://github.com/Haruki1090/notion-dart-kit
 repository: https://github.com/Haruki1090/notion-dart-kit
 issue_tracker: https://github.com/Haruki1090/notion-dart-kit/issues
 
 environment:
-  sdk: '>=3.8.0 <4.0.0'
+  sdk: '>=3.5.0 <4.0.0'
 
 platforms:
   android:


### PR DESCRIPTION
## Summary
Resolves installation issues for users with Dart SDK 3.5.x - 3.7.x by lowering the minimum SDK requirement from 3.8.0 to 3.5.0.

## Changes
- Changed SDK constraint in pubspec.yaml from `>=3.8.0 <4.0.0` to `>=3.5.0 <4.0.0`
- Bumped version from 0.2.3 to 0.2.4
- Updated CHANGELOG.md with bugfix entry

## Impact
Previously published versions (0.1.1 - 0.2.3) incorrectly required Dart 3.8.0, which was not available. Users with Dart 3.7.0 (Flutter 3.35.7) could only install v0.1.0.

This change ensures compatibility with stable Flutter and Dart versions.

## Test plan
- [x] Package validation with `dart pub publish --dry-run` passed
- [x] GitHub release v0.2.4 created

🤖 Generated with [Claude Code](https://claude.com/claude-code)