### PR TITLE
feat: update Notion API version compatibility

### DIFF
--- a/lib/src/client/http_client.dart
+++ b/lib/src/client/http_client.dart
@@ -283,7 +283,7 @@ class NotionHttpClient {
   Future<Map<String, dynamic>> _executeDelete(String path) async {
     try {
       final response = await _dio.delete<Map<String, dynamic>>(path);
-      return response.data!;
+      return response.data ?? <String, dynamic>{};
     } on DioException catch (e) {
       _maybeEnqueueRetry(
         method: 'DELETE',

--- a/lib/src/models/block.dart
+++ b/lib/src/models/block.dart
@@ -461,8 +461,8 @@ class Block with _$Block {
       json['last_edited_by'] as Map<String, dynamic>,
     );
     final hasChildren = json['has_children'] as bool;
-    final archived = json['archived'] as bool;
     final inTrash = json['in_trash'] as bool? ?? false;
+    final archived = json['archived'] as bool? ?? inTrash;
 
     switch (type) {
       case 'paragraph':

--- a/lib/src/models/data_source.dart
+++ b/lib/src/models/data_source.dart
@@ -24,6 +24,7 @@ class DataSource with _$DataSource {
     required bool archived,
     required bool isInline,
     required String url,
+    @Default(false) bool inTrash,
     PageIcon? icon,
     NotionFile? cover,
   }) = _DataSource;
@@ -46,7 +47,9 @@ class DataSource with _$DataSource {
             PropertySchema.fromJson(value as Map<String, dynamic>),
           ),
         ),
-        archived: json['archived'] as bool? ?? false,
+        archived:
+            json['archived'] as bool? ?? json['in_trash'] as bool? ?? false,
+        inTrash: json['in_trash'] as bool? ?? false,
         isInline: json['is_inline'] as bool,
         url: json['url'] as String,
         icon: json['icon'] != null
@@ -67,6 +70,7 @@ class DataSource with _$DataSource {
         'properties':
             properties.map((key, value) => MapEntry(key, value.toJson())),
         'archived': archived,
+        'in_trash': inTrash,
         'is_inline': isInline,
         'url': url,
         if (icon != null) 'icon': icon!.toJson(),

--- a/lib/src/models/pagination.dart
+++ b/lib/src/models/pagination.dart
@@ -7,6 +7,7 @@ class PaginatedList<T> {
     required this.results,
     required this.hasMore,
     this.nextCursor,
+    this.requestStatus,
   });
 
   /// Creates a PaginatedList from JSON.
@@ -23,6 +24,7 @@ class PaginatedList<T> {
             .toList(),
         hasMore: json['has_more'] as bool,
         nextCursor: json['next_cursor'] as String?,
+        requestStatus: json['request_status'] as String?,
       );
 
   /// The type of objects contained in results.
@@ -38,6 +40,12 @@ class PaginatedList<T> {
   /// Used to retrieve the next page by passing as start_cursor.
   final String? nextCursor;
 
+  /// Optional status for long-running query pagination.
+  ///
+  /// Newer query endpoints can include this field when paginating deep result
+  /// sets.
+  final String? requestStatus;
+
   /// Converts this PaginatedList to JSON.
   Map<String, dynamic> toJson(Map<String, dynamic> Function(T) toJsonT) => {
         'object': 'list',
@@ -45,5 +53,6 @@ class PaginatedList<T> {
         'results': results.map(toJsonT).toList(),
         'has_more': hasMore,
         if (nextCursor != null) 'next_cursor': nextCursor,
+        if (requestStatus != null) 'request_status': requestStatus,
       };
 }

--- a/lib/src/services/data_sources_service.dart
+++ b/lib/src/services/data_sources_service.dart
@@ -44,17 +44,21 @@ class DataSourcesService {
   /// [dataSourceId] - The ID of the data source to update
   /// [title] - Optional new title
   /// [properties] - Optional property schema updates
-  /// [archived] - Optional archived status
+  /// [inTrash] - Optional trash status for current API versions.
+  /// [archived] - Deprecated alias for older API versions.
   Future<DataSource> update(
     String dataSourceId, {
     List<Map<String, dynamic>>? title,
     Map<String, dynamic>? properties,
+    bool? inTrash,
+    @Deprecated('Use inTrash. archived was removed in API version 2026-03-11.')
     bool? archived,
   }) async {
     final body = <String, dynamic>{
       if (title != null) 'title': title,
       if (properties != null) 'properties': properties,
-      if (archived != null) 'archived': archived,
+      if (inTrash != null) 'in_trash': inTrash,
+      if (inTrash == null && archived != null) 'archived': archived,
     };
 
     final response = await _httpClient.patch(

--- a/lib/src/utils/api_version.dart
+++ b/lib/src/utils/api_version.dart
@@ -4,9 +4,16 @@
 /// and their compatibility.
 class ApiVersion {
   /// The latest stable API version.
-  static const String latest = '2022-06-28';
+  static const String latest = v2026_03_11;
+
+  /// API version with 2026 breaking changes.
+  static const String v2026_03_11 = '2026-03-11';
+
+  /// API version that introduced multi-source databases and views.
+  static const String v2025_09_03 = '2025-09-03';
 
   /// Previous stable API versions.
+  static const String v2022_06_28 = '2022-06-28';
   static const String v2022_02_22 = '2022-02-22';
   static const String v2021_08_16 = '2021-08-16';
   static const String v2021_05_13 = '2021-05-13';
@@ -14,6 +21,8 @@ class ApiVersion {
   /// All supported API versions in chronological order (newest first).
   static const List<String> supportedVersions = [
     latest,
+    v2025_09_03,
+    v2022_06_28,
     v2022_02_22,
     v2021_08_16,
     v2021_05_13,
@@ -77,10 +86,63 @@ class ApiVersion {
 
     // Features introduced in different versions
     switch (version) {
-      case latest:
+      case v2026_03_11:
         features.addAll({
           'page_properties_endpoint': true,
           'multi_source_databases': true,
+          'data_sources': true,
+          'views': true,
+          'markdown_content': true,
+          'block_position': true,
+          'in_trash_only': true,
+          'meeting_notes_blocks': true,
+          'custom_emojis': true,
+          'comments_markdown': true,
+          'comments_update_delete': true,
+          'file_block_names': true,
+          'is_locked_property': true,
+          'in_trash_property': true,
+          'rich_text_properties': true,
+          'formula_properties': true,
+          'relation_properties': true,
+          'rollup_properties': true,
+        });
+        break;
+      case v2025_09_03:
+        features.addAll({
+          'page_properties_endpoint': true,
+          'multi_source_databases': true,
+          'data_sources': true,
+          'views': true,
+          'markdown_content': false,
+          'block_position': false,
+          'in_trash_only': false,
+          'meeting_notes_blocks': false,
+          'custom_emojis': false,
+          'comments_markdown': false,
+          'comments_update_delete': false,
+          'file_block_names': true,
+          'is_locked_property': true,
+          'in_trash_property': true,
+          'rich_text_properties': true,
+          'formula_properties': true,
+          'relation_properties': true,
+          'rollup_properties': true,
+        });
+        break;
+      case v2022_06_28:
+        features.addAll({
+          'page_properties_endpoint': true,
+          'multi_source_databases': false,
+          'data_sources': false,
+          'views': false,
+          'markdown_content': false,
+          'block_position': false,
+          'in_trash_only': false,
+          'meeting_notes_blocks': false,
+          'custom_emojis': false,
+          'comments_markdown': false,
+          'comments_update_delete': false,
           'file_block_names': true,
           'is_locked_property': true,
           'in_trash_property': true,
@@ -94,6 +156,15 @@ class ApiVersion {
         features.addAll({
           'page_properties_endpoint': false,
           'multi_source_databases': false,
+          'data_sources': false,
+          'views': false,
+          'markdown_content': false,
+          'block_position': false,
+          'in_trash_only': false,
+          'meeting_notes_blocks': false,
+          'custom_emojis': false,
+          'comments_markdown': false,
+          'comments_update_delete': false,
           'file_block_names': false,
           'is_locked_property': false,
           'in_trash_property': false,
@@ -107,6 +178,15 @@ class ApiVersion {
         features.addAll({
           'page_properties_endpoint': false,
           'multi_source_databases': false,
+          'data_sources': false,
+          'views': false,
+          'markdown_content': false,
+          'block_position': false,
+          'in_trash_only': false,
+          'meeting_notes_blocks': false,
+          'custom_emojis': false,
+          'comments_markdown': false,
+          'comments_update_delete': false,
           'file_block_names': false,
           'is_locked_property': false,
           'in_trash_property': false,
@@ -120,6 +200,15 @@ class ApiVersion {
         features.addAll({
           'page_properties_endpoint': false,
           'multi_source_databases': false,
+          'data_sources': false,
+          'views': false,
+          'markdown_content': false,
+          'block_position': false,
+          'in_trash_only': false,
+          'meeting_notes_blocks': false,
+          'custom_emojis': false,
+          'comments_markdown': false,
+          'comments_update_delete': false,
           'file_block_names': false,
           'is_locked_property': false,
           'in_trash_property': false,

--- a/test/api_version_test.dart
+++ b/test/api_version_test.dart
@@ -4,11 +4,13 @@ import 'package:test/test.dart';
 void main() {
   group('ApiVersion', () {
     test('should have correct latest version', () {
-      expect(ApiVersion.latest, equals('2022-06-28'));
+      expect(ApiVersion.latest, equals('2026-03-11'));
       expect(ApiVersion.defaultVersion, equals(ApiVersion.latest));
     });
 
     test('should validate supported versions', () {
+      expect(ApiVersion.isSupported('2026-03-11'), isTrue);
+      expect(ApiVersion.isSupported('2025-09-03'), isTrue);
       expect(ApiVersion.isSupported('2022-06-28'), isTrue);
       expect(ApiVersion.isSupported('2022-02-22'), isTrue);
       expect(ApiVersion.isSupported('2021-08-16'), isTrue);
@@ -110,7 +112,7 @@ void main() {
         apiVersion: '2022-06-28',
       );
       expect(client.supportsMinimumVersion('2022-02-22'), isTrue);
-      expect(client.supportsMinimumVersion('2023-01-01'), isFalse);
+      expect(client.supportsMinimumVersion('2026-03-11'), isFalse);
     });
 
     test('should provide available features', () {

--- a/test/data_sources_service_test.mocks.dart
+++ b/test/data_sources_service_test.mocks.dart
@@ -61,9 +61,8 @@ class MockNotionHttpClient extends _i1.Mock implements _i2.NotionHttpClient {
           [path],
           {#queryParameters: queryParameters},
         ),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
-        ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
@@ -72,10 +71,13 @@ class MockNotionHttpClient extends _i1.Mock implements _i2.NotionHttpClient {
     Map<String, dynamic>? data,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(#post, [path], {#data: data}),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
+        Invocation.method(
+          #post,
+          [path],
+          {#data: data},
         ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
@@ -84,10 +86,13 @@ class MockNotionHttpClient extends _i1.Mock implements _i2.NotionHttpClient {
     required _i5.FormData? formData,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(#postMultipart, [path], {#formData: formData}),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
+        Invocation.method(
+          #postMultipart,
+          [path],
+          {#formData: formData},
         ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
@@ -96,23 +101,31 @@ class MockNotionHttpClient extends _i1.Mock implements _i2.NotionHttpClient {
     Map<String, dynamic>? data,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(#patch, [path], {#data: data}),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
+        Invocation.method(
+          #patch,
+          [path],
+          {#data: data},
         ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
   _i4.Future<Map<String, dynamic>> delete(String? path) => (super.noSuchMethod(
-        Invocation.method(#delete, [path]),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
+        Invocation.method(
+          #delete,
+          [path],
         ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
   void close() => super.noSuchMethod(
-        Invocation.method(#close, []),
+        Invocation.method(
+          #close,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 }

--- a/test/pages_service_test.mocks.dart
+++ b/test/pages_service_test.mocks.dart
@@ -61,9 +61,8 @@ class MockNotionHttpClient extends _i1.Mock implements _i2.NotionHttpClient {
           [path],
           {#queryParameters: queryParameters},
         ),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
-        ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
@@ -72,10 +71,13 @@ class MockNotionHttpClient extends _i1.Mock implements _i2.NotionHttpClient {
     Map<String, dynamic>? data,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(#post, [path], {#data: data}),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
+        Invocation.method(
+          #post,
+          [path],
+          {#data: data},
         ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
@@ -84,10 +86,13 @@ class MockNotionHttpClient extends _i1.Mock implements _i2.NotionHttpClient {
     required _i5.FormData? formData,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(#postMultipart, [path], {#formData: formData}),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
+        Invocation.method(
+          #postMultipart,
+          [path],
+          {#formData: formData},
         ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
@@ -96,23 +101,31 @@ class MockNotionHttpClient extends _i1.Mock implements _i2.NotionHttpClient {
     Map<String, dynamic>? data,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(#patch, [path], {#data: data}),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
+        Invocation.method(
+          #patch,
+          [path],
+          {#data: data},
         ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
   _i4.Future<Map<String, dynamic>> delete(String? path) => (super.noSuchMethod(
-        Invocation.method(#delete, [path]),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
+        Invocation.method(
+          #delete,
+          [path],
         ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
   void close() => super.noSuchMethod(
-        Invocation.method(#close, []),
+        Invocation.method(
+          #close,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 }

--- a/test/templates_service_test.mocks.dart
+++ b/test/templates_service_test.mocks.dart
@@ -61,9 +61,8 @@ class MockNotionHttpClient extends _i1.Mock implements _i2.NotionHttpClient {
           [path],
           {#queryParameters: queryParameters},
         ),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
-        ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
@@ -72,10 +71,13 @@ class MockNotionHttpClient extends _i1.Mock implements _i2.NotionHttpClient {
     Map<String, dynamic>? data,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(#post, [path], {#data: data}),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
+        Invocation.method(
+          #post,
+          [path],
+          {#data: data},
         ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
@@ -84,10 +86,13 @@ class MockNotionHttpClient extends _i1.Mock implements _i2.NotionHttpClient {
     required _i5.FormData? formData,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(#postMultipart, [path], {#formData: formData}),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
+        Invocation.method(
+          #postMultipart,
+          [path],
+          {#formData: formData},
         ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
@@ -96,23 +101,31 @@ class MockNotionHttpClient extends _i1.Mock implements _i2.NotionHttpClient {
     Map<String, dynamic>? data,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(#patch, [path], {#data: data}),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
+        Invocation.method(
+          #patch,
+          [path],
+          {#data: data},
         ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
   _i4.Future<Map<String, dynamic>> delete(String? path) => (super.noSuchMethod(
-        Invocation.method(#delete, [path]),
-        returnValue: _i4.Future<Map<String, dynamic>>.value(
-          <String, dynamic>{},
+        Invocation.method(
+          #delete,
+          [path],
         ),
+        returnValue:
+            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
   void close() => super.noSuchMethod(
-        Invocation.method(#close, []),
+        Invocation.method(
+          #close,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 }


### PR DESCRIPTION
## Summary
- Update `ApiVersion.latest` to `2026-03-11` and add latest version constants/feature metadata
- Prefer `in_trash` while tolerating older `archived` payloads for relevant models
- Add paginated `request_status` support and robust empty DELETE response handling
- Regenerate affected HTTP client mocks

## Verification
- `dart analyze`
- `dart test test/api_version_test.dart test/data_sources_service_test.dart test/pagination_test.dart`