### PR TITLE
feat: add latest Notion content APIs

### DIFF
--- a/lib/src/models/file.dart
+++ b/lib/src/models/file.dart
@@ -68,6 +68,17 @@ class PageIcon with _$PageIcon {
 
   const factory PageIcon.file({required NotionFile file}) = FilePageIcon;
 
+  const factory PageIcon.customEmoji({
+    required String id,
+    required String name,
+    required String url,
+  }) = CustomEmojiPageIcon;
+
+  const factory PageIcon.notionIcon({
+    required String name,
+    String? color,
+  }) = NotionNativePageIcon;
+
   factory PageIcon.fromJson(Map<String, dynamic> json) {
     final type = json['type'] as String;
 
@@ -77,6 +88,19 @@ class PageIcon with _$PageIcon {
       case 'external':
       case 'file':
         return PageIcon.file(file: NotionFile.fromJson(json));
+      case 'custom_emoji':
+        final customEmoji = json['custom_emoji'] as Map<String, dynamic>;
+        return PageIcon.customEmoji(
+          id: customEmoji['id'] as String,
+          name: customEmoji['name'] as String,
+          url: customEmoji['url'] as String,
+        );
+      case 'icon':
+        final icon = json['icon'] as Map<String, dynamic>;
+        return PageIcon.notionIcon(
+          name: icon['name'] as String,
+          color: icon['color'] as String?,
+        );
       default:
         throw ArgumentError('Unknown icon type: $type');
     }
@@ -85,5 +109,20 @@ class PageIcon with _$PageIcon {
   Map<String, dynamic> toJson() => map(
         emoji: (icon) => {'type': 'emoji', 'emoji': icon.emoji},
         file: (icon) => icon.file.toJson(),
+        customEmoji: (icon) => {
+          'type': 'custom_emoji',
+          'custom_emoji': {
+            'id': icon.id,
+            'name': icon.name,
+            'url': icon.url,
+          },
+        },
+        notionIcon: (icon) => {
+          'type': 'icon',
+          'icon': {
+            'name': icon.name,
+            if (icon.color != null) 'color': icon.color,
+          },
+        },
       );
 }

--- a/lib/src/models/page.dart
+++ b/lib/src/models/page.dart
@@ -39,7 +39,10 @@ class Page with _$Page {
         lastEditedBy:
             User.fromJson(json['last_edited_by'] as Map<String, dynamic>),
         parent: Parent.fromJson(json['parent'] as Map<String, dynamic>),
-        archived: json['archived'] as bool,
+        archived: json['archived'] as bool? ??
+            json['is_archived'] as bool? ??
+            json['in_trash'] as bool? ??
+            false,
         inTrash: json['in_trash'] as bool? ?? false,
         isLocked: json['is_locked'] as bool? ?? false,
         properties: (json['properties'] as Map<String, dynamic>).map(
@@ -70,6 +73,141 @@ class Page with _$Page {
         if (icon != null) 'icon': icon!.toJson(),
         if (cover != null) 'cover': cover!.toJson(),
         if (publicUrl != null) 'public_url': publicUrl,
+      };
+}
+
+/// Response object returned by Notion page markdown endpoints.
+class PageMarkdown {
+  const PageMarkdown({
+    required this.object,
+    required this.id,
+    required this.markdown,
+    required this.truncated,
+    required this.unknownBlockIds,
+  });
+
+  factory PageMarkdown.fromJson(Map<String, dynamic> json) => PageMarkdown(
+        object: json['object'] as String,
+        id: json['id'] as String,
+        markdown: json['markdown'] as String,
+        truncated: json['truncated'] as bool? ?? false,
+        unknownBlockIds: (json['unknown_block_ids'] as List<dynamic>? ?? [])
+            .map((e) => e as String)
+            .toList(),
+      );
+
+  final String object;
+  final String id;
+  final String markdown;
+  final bool truncated;
+  final List<String> unknownBlockIds;
+
+  Map<String, dynamic> toJson() => {
+        'object': object,
+        'id': id,
+        'markdown': markdown,
+        'truncated': truncated,
+        'unknown_block_ids': unknownBlockIds,
+      };
+}
+
+/// A search-and-replace operation for the `update_content` markdown command.
+class MarkdownContentUpdate {
+  const MarkdownContentUpdate({
+    required this.oldStr,
+    required this.newStr,
+    this.replaceAllMatches,
+  });
+
+  final String oldStr;
+  final String newStr;
+  final bool? replaceAllMatches;
+
+  Map<String, dynamic> toJson() => {
+        'old_str': oldStr,
+        'new_str': newStr,
+        if (replaceAllMatches != null) 'replace_all_matches': replaceAllMatches,
+      };
+}
+
+/// Request command for `PATCH /v1/pages/:page_id/markdown`.
+class MarkdownUpdateCommand {
+  const MarkdownUpdateCommand._(this._json);
+
+  factory MarkdownUpdateCommand.updateContent({
+    required List<MarkdownContentUpdate> contentUpdates,
+    bool? allowDeletingContent,
+  }) =>
+      MarkdownUpdateCommand._({
+        'type': 'update_content',
+        'update_content': {
+          'content_updates': contentUpdates.map((e) => e.toJson()).toList(),
+          if (allowDeletingContent != null)
+            'allow_deleting_content': allowDeletingContent,
+        },
+      });
+
+  factory MarkdownUpdateCommand.replaceContent({
+    required String newStr,
+    bool? allowDeletingContent,
+  }) =>
+      MarkdownUpdateCommand._({
+        'type': 'replace_content',
+        'replace_content': {
+          'new_str': newStr,
+          if (allowDeletingContent != null)
+            'allow_deleting_content': allowDeletingContent,
+        },
+      });
+
+  factory MarkdownUpdateCommand.insertContent({
+    required String content,
+    String? after,
+  }) =>
+      MarkdownUpdateCommand._({
+        'type': 'insert_content',
+        'insert_content': {
+          'content': content,
+          if (after != null) 'after': after,
+        },
+      });
+
+  factory MarkdownUpdateCommand.replaceContentRange({
+    required String content,
+    required String contentRange,
+    bool? allowDeletingContent,
+  }) =>
+      MarkdownUpdateCommand._({
+        'type': 'replace_content_range',
+        'replace_content_range': {
+          'content': content,
+          'content_range': contentRange,
+          if (allowDeletingContent != null)
+            'allow_deleting_content': allowDeletingContent,
+        },
+      });
+
+  final Map<String, dynamic> _json;
+
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(_json);
+}
+
+/// Template application body for create/update page template support.
+class PageTemplateApply {
+  const PageTemplateApply({
+    required this.templateId,
+    this.type = 'template_id',
+    this.timezone,
+  });
+
+  final String templateId;
+  final String type;
+  final String? timezone;
+
+  Map<String, dynamic> toJson() => {
+        'type': type,
+        'template_id': templateId,
+        if (timezone != null) 'timezone': timezone,
       };
 }
 

--- a/lib/src/services/blocks_service.dart
+++ b/lib/src/services/blocks_service.dart
@@ -69,11 +69,15 @@ class BlocksService {
   /// Note: You can pass up to 100 children at a time.
   Future<BlockChildren> appendChildren(
     String blockId,
-    List<Map<String, dynamic>> children,
-  ) async {
+    List<Map<String, dynamic>> children, {
+    BlockPosition? position,
+  }) async {
     final response = await _httpClient.patch(
       '/blocks/$blockId/children',
-      data: {'children': children},
+      data: {
+        'children': children,
+        if (position != null) 'position': position.toJson(),
+      },
     );
 
     return BlockChildren.fromJson(response);
@@ -95,14 +99,44 @@ class BlocksService {
 
   /// Deletes a block
   ///
-  /// Sets a Block object, including page blocks, to archived: true using
-  /// the ID specified. Archived blocks will not appear in the UI.
+  /// Moves a block to trash using the ID specified.
   ///
-  /// Note: This sets archived to true, it doesn't permanently delete the block.
+  /// Note: This doesn't permanently delete the block.
   Future<Block> delete(String blockId) async {
     final response = await _httpClient.delete('/blocks/$blockId');
     return Block.fromJson(response);
   }
+}
+
+/// Position used when appending children in API version 2026-03-11 or newer.
+class BlockPosition {
+  const BlockPosition._(this._json);
+
+  factory BlockPosition.afterBlock(String blockId) => BlockPosition._({
+        'type': 'after_block',
+        'after_block': {'block_id': blockId},
+      });
+
+  const factory BlockPosition.start() = _StartBlockPosition;
+  const factory BlockPosition.end() = _EndBlockPosition;
+
+  final Map<String, dynamic> _json;
+
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(_json);
+}
+
+class _StartBlockPosition extends BlockPosition {
+  const _StartBlockPosition() : super._(const {});
+
+  @override
+  Map<String, dynamic> toJson() => {'type': 'start', 'start': {}};
+}
+
+class _EndBlockPosition extends BlockPosition {
+  const _EndBlockPosition() : super._(const {});
+
+  @override
+  Map<String, dynamic> toJson() => {'type': 'end', 'end': {}};
 }
 
 /// Block children response with pagination.

--- a/lib/src/services/comments_service.dart
+++ b/lib/src/services/comments_service.dart
@@ -13,14 +13,15 @@ class CommentsService {
   ///
   /// Exactly one of [parent] or [discussionId] must be provided.
   /// - When using [parent], only `page_id` or `block_id` are valid parent types.
-  /// - [richText] is the comment content.
+  /// - Provide exactly one of [richText] or [markdown] for the comment body.
   /// - [attachments] is an optional array of request objects containing `file_upload_id`.
   /// - [displayName] optional request object to override author display name.
   ///
   /// Returns the created [Comment].
   /// Throws [NotionException] if the request fails.
   Future<Comment> create({
-    required List<RichText> richText,
+    List<RichText>? richText,
+    String? markdown,
     Parent? parent,
     String? discussionId,
     List<Map<String, dynamic>>? attachments,
@@ -35,11 +36,14 @@ class CommentsService {
         statusCode: 400,
       );
     }
+    _validateBody(richText: richText, markdown: markdown);
 
     final body = <String, dynamic>{
       if (parent != null) 'parent': parent.toJson(),
       if (discussionId != null) 'discussion_id': discussionId,
-      'rich_text': richText.map((e) => e.toJson()).toList(),
+      if (richText != null)
+        'rich_text': richText.map((e) => e.toJson()).toList(),
+      if (markdown != null) 'markdown': markdown,
       if (attachments != null) 'attachments': attachments,
       if (displayName != null) 'display_name': displayName,
     };
@@ -76,5 +80,48 @@ class CommentsService {
   Future<Comment> retrieve(String commentId) async {
     final response = await _httpClient.get('/comments/$commentId');
     return Comment.fromJson(response);
+  }
+
+  /// Updates a comment by its ID.
+  ///
+  /// Provide exactly one of [richText] or [markdown].
+  Future<Comment> update(
+    String commentId, {
+    List<RichText>? richText,
+    String? markdown,
+    List<Map<String, dynamic>>? attachments,
+    Map<String, dynamic>? displayName,
+  }) async {
+    _validateBody(richText: richText, markdown: markdown);
+
+    final body = <String, dynamic>{
+      if (richText != null)
+        'rich_text': richText.map((e) => e.toJson()).toList(),
+      if (markdown != null) 'markdown': markdown,
+      if (attachments != null) 'attachments': attachments,
+      if (displayName != null) 'display_name': displayName,
+    };
+
+    final response =
+        await _httpClient.patch('/comments/$commentId', data: body);
+    return Comment.fromJson(response);
+  }
+
+  /// Deletes a comment by its ID.
+  ///
+  /// The API can return either a partial or full comment object, so this method
+  /// returns the raw response map.
+  Future<Map<String, dynamic>> delete(String commentId) =>
+      _httpClient.delete('/comments/$commentId');
+
+  void _validateBody({List<RichText>? richText, String? markdown}) {
+    final hasRichText = richText != null;
+    final hasMarkdown = markdown != null && markdown.isNotEmpty;
+    if (hasRichText == hasMarkdown) {
+      throw ValidationException(
+        'Exactly one of richText or markdown must be provided',
+        statusCode: 400,
+      );
+    }
   }
 }

--- a/lib/src/services/pages_service.dart
+++ b/lib/src/services/pages_service.dart
@@ -1,10 +1,9 @@
-import '../../notion_dart_kit.dart' show NotionException;
+import '../../notion_dart_kit.dart' show NotionException, ValidationException;
 import '../client/http_client.dart';
 import '../models/file.dart';
 import '../models/page.dart';
 import '../models/parent.dart';
 import '../models/property_item.dart';
-import '../utils/exceptions.dart' show NotionException;
 
 /// Service for interacting with Notion Pages API
 class PagesService {
@@ -37,17 +36,36 @@ class PagesService {
     required Parent parent,
     required Map<String, dynamic> properties,
     List<Map<String, dynamic>>? children,
+    String? markdown,
     PageIcon? icon,
     NotionFile? cover,
     String? templateId,
+    PageTemplateApply? template,
+    Map<String, dynamic>? position,
   }) async {
+    if (children != null && markdown != null) {
+      throw ValidationException(
+        'children and markdown are mutually exclusive',
+        statusCode: 400,
+      );
+    }
+    if (templateId != null && template != null) {
+      throw ValidationException(
+        'templateId and template are mutually exclusive',
+        statusCode: 400,
+      );
+    }
+
     final body = <String, dynamic>{
       'parent': parent.toJson(),
       'properties': properties,
       if (children != null) 'children': children,
+      if (markdown != null) 'markdown': markdown,
       if (icon != null) 'icon': icon.toJson(),
       if (cover != null) 'cover': cover.toJson(),
       if (templateId != null) 'template_id': templateId,
+      if (template != null) 'template': template.toJson(),
+      if (position != null) 'position': position,
     };
 
     final response = await _httpClient.post('/pages', data: body);
@@ -93,6 +111,8 @@ class PagesService {
     NotionFile? cover,
     bool? inTrash,
     bool? isLocked,
+    PageTemplateApply? template,
+    bool? eraseContent,
   }) async {
     final body = <String, dynamic>{};
     if (properties != null) {
@@ -110,10 +130,25 @@ class PagesService {
     if (isLocked != null) {
       body['is_locked'] = isLocked;
     }
+    if (template != null) {
+      body['template'] = template.toJson();
+    }
+    if (eraseContent != null) {
+      body['erase_content'] = eraseContent;
+    }
 
     final response = await _httpClient.patch('/pages/$pageId', data: body);
     return Page.fromJson(response);
   }
+
+  /// Moves a page to a new parent.
+  ///
+  /// The parent must be a page or data source parent in current Notion API.
+  Future<Map<String, dynamic>> move(String pageId, {required Parent parent}) =>
+      _httpClient.post(
+        '/pages/$pageId/move',
+        data: {'parent': parent.toJson()},
+      );
 
   /// Archives a page by moving it to trash.
   ///
@@ -160,5 +195,31 @@ class PagesService {
     );
 
     return PropertyItemList.fromJson(response);
+  }
+
+  /// Retrieves page content rendered as enhanced markdown.
+  Future<PageMarkdown> retrieveMarkdown(
+    String pageId, {
+    bool? includeTranscript,
+  }) async {
+    final response = await _httpClient.get(
+      '/pages/$pageId/markdown',
+      queryParameters: includeTranscript == null
+          ? null
+          : {'include_transcript': includeTranscript},
+    );
+    return PageMarkdown.fromJson(response);
+  }
+
+  /// Updates page content using enhanced markdown commands.
+  Future<PageMarkdown> updateMarkdown(
+    String pageId,
+    MarkdownUpdateCommand command,
+  ) async {
+    final response = await _httpClient.patch(
+      '/pages/$pageId/markdown',
+      data: command.toJson(),
+    );
+    return PageMarkdown.fromJson(response);
   }
 }

--- a/lib/src/utils/block_builder.dart
+++ b/lib/src/utils/block_builder.dart
@@ -72,6 +72,10 @@ class BlockBuilder {
   static HeadingBlockBuilder heading3(String text) =>
       HeadingBlockBuilder._(text, 3);
 
+  /// Creates a heading 4 block.
+  static HeadingBlockBuilder heading4(String text) =>
+      HeadingBlockBuilder._(text, 4);
+
   /// Creates a quote block
   ///
   /// Example:
@@ -271,6 +275,12 @@ class BlockBuilder {
         hasColumnHeader: hasColumnHeader,
         hasRowHeader: hasRowHeader,
       );
+
+  /// Creates a tab block.
+  static TabBlockBuilder tab({
+    List<Map<String, dynamic>> children = const [],
+  }) =>
+      TabBlockBuilder(children);
 }
 
 // ========================================
@@ -607,6 +617,21 @@ class BreadcrumbBlockBuilder {
         'object': 'block',
         'type': 'breadcrumb',
         'breadcrumb': {},
+      };
+}
+
+/// Builder for tab blocks.
+class TabBlockBuilder {
+  TabBlockBuilder(this._children);
+
+  final List<Map<String, dynamic>> _children;
+
+  Map<String, dynamic> toJson() => {
+        'object': 'block',
+        'type': 'tab',
+        'tab': {
+          if (_children.isNotEmpty) 'children': _children,
+        },
       };
 }
 

--- a/test/block_builder_test.dart
+++ b/test/block_builder_test.dart
@@ -93,6 +93,13 @@ void main() {
       expect(block['heading_3']['is_toggleable'], true);
     });
 
+    test('heading 4 generates correct JSON', () {
+      final block = BlockBuilder.heading4('Detail').toJson();
+
+      expect(block['type'], 'heading_4');
+      expect(block['heading_4']['rich_text'][0]['text']['content'], 'Detail');
+    });
+
     test('toggleable heading with children', () {
       final block =
           BlockBuilder.heading2('Toggle Heading').toggleable().children(
@@ -101,6 +108,17 @@ void main() {
 
       expect(block['heading_2']['is_toggleable'], true);
       expect(block['heading_2']['children'], hasLength(1));
+    });
+  });
+
+  group('BlockBuilder - Tabs', () {
+    test('tab generates correct JSON', () {
+      final block = BlockBuilder.tab(
+        children: [BlockBuilder.paragraph('Tab content').toJson()],
+      ).toJson();
+
+      expect(block['type'], 'tab');
+      expect(block['tab']['children'], hasLength(1));
     });
   });
 

--- a/test/pages_service_test.dart
+++ b/test/pages_service_test.dart
@@ -58,6 +58,8 @@ void main() {
       icon.map(
         emoji: (emojiIcon) => expect(emojiIcon.emoji, '🚀'),
         file: (_) => fail('Expected emoji icon'),
+        customEmoji: (_) => fail('Expected emoji icon'),
+        notionIcon: (_) => fail('Expected emoji icon'),
       );
     });
 


### PR DESCRIPTION
## Summary
- Add markdown page create/retrieve/update support
- Add structured page template application, page move, and erase-content support
- Add block append positioning and new heading4/tab builders
- Add markdown comment creation plus comment update/delete APIs
- Add custom emoji and notion icon page icon variants

## Verification
- `dart analyze`
- `dart test test/block_builder_test.dart test/pages_service_test.dart test/templates_service_test.dart`