### PR TITLE
feat: add Notion views and custom emojis

### DIFF
--- a/lib/notion_dart_kit.dart
+++ b/lib/notion_dart_kit.dart
@@ -14,6 +14,7 @@ export 'src/client/retry_queue.dart';
 export 'src/models/block.dart';
 export 'src/models/block_content.dart';
 export 'src/models/comment.dart';
+export 'src/models/custom_emoji.dart';
 export 'src/models/data_source.dart';
 export 'src/models/database.dart';
 export 'src/models/file.dart';
@@ -27,6 +28,7 @@ export 'src/models/property_value.dart';
 export 'src/models/rich_text.dart';
 export 'src/models/template.dart';
 export 'src/models/user.dart';
+export 'src/models/view.dart';
 // Query DSL
 export 'src/query/filter.dart';
 export 'src/query/filter_builder.dart';
@@ -34,6 +36,7 @@ export 'src/query/sort.dart';
 // Services
 export 'src/services/blocks_service.dart';
 export 'src/services/comments_service.dart';
+export 'src/services/custom_emojis_service.dart';
 export 'src/services/data_sources_service.dart';
 export 'src/services/databases_service.dart';
 export 'src/services/file_uploads_service.dart';
@@ -41,6 +44,7 @@ export 'src/services/pages_service.dart';
 export 'src/services/search_service.dart';
 export 'src/services/templates_service.dart';
 export 'src/services/users_service.dart';
+export 'src/services/views_service.dart';
 // Utilities
 export 'src/utils/api_version.dart';
 export 'src/utils/block_builder.dart';

--- a/lib/src/client/notion_client.dart
+++ b/lib/src/client/notion_client.dart
@@ -1,5 +1,6 @@
 import '../services/blocks_service.dart';
 import '../services/comments_service.dart';
+import '../services/custom_emojis_service.dart';
 import '../services/data_sources_service.dart';
 import '../services/databases_service.dart';
 import '../services/file_uploads_service.dart';
@@ -7,6 +8,7 @@ import '../services/pages_service.dart';
 import '../services/search_service.dart';
 import '../services/templates_service.dart';
 import '../services/users_service.dart';
+import '../services/views_service.dart';
 import 'http_client.dart';
 import 'retry_queue.dart';
 
@@ -41,6 +43,8 @@ class NotionClient {
     comments = CommentsService(httpClient);
     fileUploads = FileUploadsService(httpClient);
     templates = TemplatesService(httpClient);
+    views = ViewsService(httpClient);
+    customEmojis = CustomEmojisService(httpClient);
   }
 
   /// The HTTP client used for API requests.
@@ -95,6 +99,12 @@ class NotionClient {
   /// Provides methods to retrieve templates from data sources and use them
   /// for creating new pages with predefined structures.
   late final TemplatesService templates;
+
+  /// Service for Views API endpoints.
+  late final ViewsService views;
+
+  /// Service for Custom Emojis API endpoints.
+  late final CustomEmojisService customEmojis;
 
   /// The Notion API integration token.
   ///

--- a/lib/src/models/custom_emoji.dart
+++ b/lib/src/models/custom_emoji.dart
@@ -1,0 +1,24 @@
+/// Custom emoji object in a Notion workspace.
+class CustomEmoji {
+  const CustomEmoji({
+    required this.id,
+    required this.name,
+    required this.url,
+  });
+
+  factory CustomEmoji.fromJson(Map<String, dynamic> json) => CustomEmoji(
+        id: json['id'] as String,
+        name: json['name'] as String,
+        url: json['url'] as String,
+      );
+
+  final String id;
+  final String name;
+  final String url;
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'url': url,
+      };
+}

--- a/lib/src/models/view.dart
+++ b/lib/src/models/view.dart
@@ -1,0 +1,110 @@
+/// A Notion database view.
+///
+/// View configuration is intentionally stored as raw JSON because Notion has a
+/// large, fast-moving configuration schema per view type.
+class View {
+  const View({
+    required this.object,
+    required this.id,
+    required this.name,
+    required this.type,
+    this.parent,
+    this.dataSourceId,
+    this.databaseId,
+    this.dashboardViewId,
+    this.filter,
+    this.sorts,
+    this.configuration,
+    this.raw,
+  });
+
+  factory View.fromJson(Map<String, dynamic> json) => View(
+        object: json['object'] as String? ?? 'view',
+        id: json['id'] as String,
+        name: json['name'] as String? ?? '',
+        type: json['type'] as String,
+        parent: json['parent'] as Map<String, dynamic>?,
+        dataSourceId: json['data_source_id'] as String?,
+        databaseId: json['database_id'] as String?,
+        dashboardViewId: json['dashboard_view_id'] as String?,
+        filter: json['filter'] as Map<String, dynamic>?,
+        sorts: (json['sorts'] as List<dynamic>?)
+            ?.map((e) => e as Map<String, dynamic>)
+            .toList(),
+        configuration: json['configuration'] as Map<String, dynamic>?,
+        raw: Map<String, dynamic>.from(json),
+      );
+
+  final String object;
+  final String id;
+  final String name;
+  final String type;
+  final Map<String, dynamic>? parent;
+  final String? dataSourceId;
+  final String? databaseId;
+  final String? dashboardViewId;
+  final Map<String, dynamic>? filter;
+  final List<Map<String, dynamic>>? sorts;
+  final Map<String, dynamic>? configuration;
+  final Map<String, dynamic>? raw;
+
+  Map<String, dynamic> toJson() =>
+      raw ??
+      {
+        'object': object,
+        'id': id,
+        'name': name,
+        'type': type,
+        if (parent != null) 'parent': parent,
+        if (dataSourceId != null) 'data_source_id': dataSourceId,
+        if (databaseId != null) 'database_id': databaseId,
+        if (dashboardViewId != null) 'dashboard_view_id': dashboardViewId,
+        if (filter != null) 'filter': filter,
+        if (sorts != null) 'sorts': sorts,
+        if (configuration != null) 'configuration': configuration,
+      };
+}
+
+/// Response from creating a cached view query.
+class ViewQuery {
+  const ViewQuery({
+    required this.object,
+    required this.id,
+    required this.results,
+    required this.hasMore,
+    this.nextCursor,
+    this.requestStatus,
+    this.raw,
+  });
+
+  factory ViewQuery.fromJson(Map<String, dynamic> json) => ViewQuery(
+        object: json['object'] as String? ?? 'list',
+        id: json['id'] as String? ?? json['query_id'] as String? ?? '',
+        results: (json['results'] as List<dynamic>? ?? [])
+            .map((e) => e as Map<String, dynamic>)
+            .toList(),
+        hasMore: json['has_more'] as bool? ?? false,
+        nextCursor: json['next_cursor'] as String?,
+        requestStatus: json['request_status'] as String?,
+        raw: Map<String, dynamic>.from(json),
+      );
+
+  final String object;
+  final String id;
+  final List<Map<String, dynamic>> results;
+  final bool hasMore;
+  final String? nextCursor;
+  final String? requestStatus;
+  final Map<String, dynamic>? raw;
+
+  Map<String, dynamic> toJson() =>
+      raw ??
+      {
+        'object': object,
+        'id': id,
+        'results': results,
+        'has_more': hasMore,
+        if (nextCursor != null) 'next_cursor': nextCursor,
+        if (requestStatus != null) 'request_status': requestStatus,
+      };
+}

--- a/lib/src/services/custom_emojis_service.dart
+++ b/lib/src/services/custom_emojis_service.dart
@@ -1,0 +1,26 @@
+import '../client/http_client.dart';
+import '../models/custom_emoji.dart';
+import '../models/pagination.dart';
+
+/// Service for Notion custom emoji endpoints.
+class CustomEmojisService {
+  CustomEmojisService(this._httpClient);
+  final NotionHttpClient _httpClient;
+
+  /// Lists workspace custom emojis.
+  Future<PaginatedList<CustomEmoji>> list({
+    String? name,
+    String? startCursor,
+    int? pageSize,
+  }) async {
+    final response = await _httpClient.get(
+      '/custom_emojis',
+      queryParameters: {
+        if (name != null) 'name': name,
+        if (startCursor != null) 'start_cursor': startCursor,
+        if (pageSize != null) 'page_size': pageSize.clamp(1, 100),
+      },
+    );
+    return PaginatedList.fromJson(response, CustomEmoji.fromJson);
+  }
+}

--- a/lib/src/services/views_service.dart
+++ b/lib/src/services/views_service.dart
@@ -1,0 +1,135 @@
+import '../client/http_client.dart';
+import '../models/pagination.dart';
+import '../models/view.dart';
+
+/// Service for Notion Views API.
+class ViewsService {
+  ViewsService(this._httpClient);
+  final NotionHttpClient _httpClient;
+
+  /// Lists views by database or data source.
+  Future<PaginatedList<View>> list({
+    String? databaseId,
+    String? dataSourceId,
+    String? startCursor,
+    int? pageSize,
+  }) async {
+    if ((databaseId == null) == (dataSourceId == null)) {
+      throw ArgumentError(
+        'Exactly one of databaseId or dataSourceId is required',
+      );
+    }
+
+    final response = await _httpClient.get(
+      '/views',
+      queryParameters: {
+        if (databaseId != null) 'database_id': databaseId,
+        if (dataSourceId != null) 'data_source_id': dataSourceId,
+        if (startCursor != null) 'start_cursor': startCursor,
+        if (pageSize != null) 'page_size': pageSize,
+      },
+    );
+    return PaginatedList.fromJson(response, View.fromJson);
+  }
+
+  /// Retrieves a view by ID.
+  Future<View> retrieve(String viewId) async {
+    final response = await _httpClient.get('/views/$viewId');
+    return View.fromJson(response);
+  }
+
+  /// Creates a view.
+  Future<View> create({
+    required String dataSourceId,
+    required String name,
+    required String type,
+    String? databaseId,
+    String? viewId,
+    Map<String, dynamic>? createDatabase,
+    Map<String, dynamic>? filter,
+    List<Map<String, dynamic>>? sorts,
+    Map<String, dynamic>? configuration,
+    Map<String, dynamic>? position,
+  }) async {
+    final parentTargets = [
+      databaseId,
+      viewId,
+      createDatabase,
+    ].where((e) => e != null).length;
+    if (parentTargets != 1) {
+      throw ArgumentError(
+        'Exactly one of databaseId, viewId, or createDatabase is required',
+      );
+    }
+
+    final response = await _httpClient.post(
+      '/views',
+      data: {
+        'data_source_id': dataSourceId,
+        'name': name,
+        'type': type,
+        if (databaseId != null) 'database_id': databaseId,
+        if (viewId != null) 'view_id': viewId,
+        if (createDatabase != null) 'create_database': createDatabase,
+        if (filter != null) 'filter': filter,
+        if (sorts != null) 'sorts': sorts,
+        if (configuration != null) 'configuration': configuration,
+        if (position != null) 'position': position,
+      },
+    );
+    return View.fromJson(response);
+  }
+
+  /// Updates a view by ID.
+  Future<View> update(
+    String viewId, {
+    String? name,
+    Map<String, dynamic>? filter,
+    List<Map<String, dynamic>>? sorts,
+    Map<String, dynamic>? configuration,
+  }) async {
+    final response = await _httpClient.patch(
+      '/views/$viewId',
+      data: {
+        if (name != null) 'name': name,
+        if (filter != null) 'filter': filter,
+        if (sorts != null) 'sorts': sorts,
+        if (configuration != null) 'configuration': configuration,
+      },
+    );
+    return View.fromJson(response);
+  }
+
+  /// Deletes a view by ID.
+  Future<View> delete(String viewId) async {
+    final response = await _httpClient.delete('/views/$viewId');
+    return View.fromJson(response);
+  }
+
+  /// Creates a cached query for a view and returns the first page of results.
+  Future<ViewQuery> createQuery(String viewId) async {
+    final response = await _httpClient.post('/views/$viewId/queries');
+    return ViewQuery.fromJson(response);
+  }
+
+  /// Retrieves a page of results from a cached view query.
+  Future<ViewQuery> retrieveQueryResults(
+    String viewId,
+    String queryId, {
+    String? startCursor,
+    int? pageSize,
+  }) async {
+    final response = await _httpClient.get(
+      '/views/$viewId/queries/$queryId',
+      queryParameters: {
+        if (startCursor != null) 'start_cursor': startCursor,
+        if (pageSize != null) 'page_size': pageSize,
+      },
+    );
+    return ViewQuery.fromJson(response);
+  }
+
+  /// Deletes a cached view query.
+  Future<Map<String, dynamic>> deleteQuery(String viewId, String queryId) =>
+      _httpClient.delete('/views/$viewId/queries/$queryId');
+}


### PR DESCRIPTION
## Summary
- Add `ViewsService`, `View`, and `ViewQuery` models for Notion Views API coverage
- Add `CustomEmojisService` and `CustomEmoji` model
- Expose both services through `NotionClient` and the public library exports

## Verification
- `dart analyze`
- `dart test test/api_version_test.dart`