### PR TITLE
feat: expand Notion query filters

### DIFF
--- a/lib/src/query/filter.dart
+++ b/lib/src/query/filter.dart
@@ -203,15 +203,48 @@ sealed class PropertyFilter with _$PropertyFilter {
   /// Select equals - matches the exact option name.
   const factory PropertyFilter.selectEquals(String value) = SelectEqualsFilter;
 
+  /// Select equals any of the option names.
+  const factory PropertyFilter.selectEqualsAny(List<String> values) =
+      SelectEqualsAnyFilter;
+
   /// Select does not equal - does not match the option name.
   const factory PropertyFilter.selectDoesNotEqual(String value) =
       SelectDoesNotEqualFilter;
+
+  /// Select does not equal any of the option names.
+  const factory PropertyFilter.selectDoesNotEqualAny(List<String> values) =
+      SelectDoesNotEqualAnyFilter;
 
   /// Select is empty - has no selected option.
   const factory PropertyFilter.selectIsEmpty() = SelectIsEmptyFilter;
 
   /// Select is not empty - has any selected option.
   const factory PropertyFilter.selectIsNotEmpty() = SelectIsNotEmptyFilter;
+
+  // ============================================
+  // Status filters
+  // ============================================
+
+  /// Status equals - matches the exact option name.
+  const factory PropertyFilter.statusEquals(String value) = StatusEqualsFilter;
+
+  /// Status equals any of the option names.
+  const factory PropertyFilter.statusEqualsAny(List<String> values) =
+      StatusEqualsAnyFilter;
+
+  /// Status does not equal - does not match the option name.
+  const factory PropertyFilter.statusDoesNotEqual(String value) =
+      StatusDoesNotEqualFilter;
+
+  /// Status does not equal any of the option names.
+  const factory PropertyFilter.statusDoesNotEqualAny(List<String> values) =
+      StatusDoesNotEqualAnyFilter;
+
+  /// Status is empty - has no selected option.
+  const factory PropertyFilter.statusIsEmpty() = StatusIsEmptyFilter;
+
+  /// Status is not empty - has any selected option.
+  const factory PropertyFilter.statusIsNotEmpty() = StatusIsNotEmptyFilter;
 
   // ============================================
   // Multi-select filters
@@ -221,9 +254,18 @@ sealed class PropertyFilter with _$PropertyFilter {
   const factory PropertyFilter.multiSelectContains(String value) =
       MultiSelectContainsFilter;
 
+  /// Multi-select contains any of the specified options.
+  const factory PropertyFilter.multiSelectContainsAny(List<String> values) =
+      MultiSelectContainsAnyFilter;
+
   /// Multi-select does not contain - does not include the specified option.
   const factory PropertyFilter.multiSelectDoesNotContain(String value) =
       MultiSelectDoesNotContainFilter;
+
+  /// Multi-select does not contain any of the specified options.
+  const factory PropertyFilter.multiSelectDoesNotContainAny(
+    List<String> values,
+  ) = MultiSelectDoesNotContainAnyFilter;
 
   /// Multi-select is empty - has no selected options.
   const factory PropertyFilter.multiSelectIsEmpty() = MultiSelectIsEmptyFilter;
@@ -387,8 +429,14 @@ sealed class PropertyFilter with _$PropertyFilter {
         selectEquals: (value) => {
           'select': {'equals': value},
         },
+        selectEqualsAny: (values) => {
+          'select': {'equals': values},
+        },
         selectDoesNotEqual: (value) => {
           'select': {'does_not_equal': value},
+        },
+        selectDoesNotEqualAny: (values) => {
+          'select': {'does_not_equal': values},
         },
         selectIsEmpty: () => {
           'select': {'is_empty': true},
@@ -397,12 +445,38 @@ sealed class PropertyFilter with _$PropertyFilter {
           'select': {'is_not_empty': true},
         },
 
+        // Status
+        statusEquals: (value) => {
+          'status': {'equals': value},
+        },
+        statusEqualsAny: (values) => {
+          'status': {'equals': values},
+        },
+        statusDoesNotEqual: (value) => {
+          'status': {'does_not_equal': value},
+        },
+        statusDoesNotEqualAny: (values) => {
+          'status': {'does_not_equal': values},
+        },
+        statusIsEmpty: () => {
+          'status': {'is_empty': true},
+        },
+        statusIsNotEmpty: () => {
+          'status': {'is_not_empty': true},
+        },
+
         // MultiSelect
         multiSelectContains: (value) => {
           'multi_select': {'contains': value},
         },
+        multiSelectContainsAny: (values) => {
+          'multi_select': {'contains': values},
+        },
         multiSelectDoesNotContain: (value) => {
           'multi_select': {'does_not_contain': value},
+        },
+        multiSelectDoesNotContainAny: (values) => {
+          'multi_select': {'does_not_contain': values},
         },
         multiSelectIsEmpty: () => {
           'multi_select': {'is_empty': true},

--- a/lib/src/query/filter_builder.dart
+++ b/lib/src/query/filter_builder.dart
@@ -24,8 +24,8 @@ class PropertyFilterBuilder {
   MultiSelectFilterBuilder multiSelect() =>
       MultiSelectFilterBuilder(propertyName);
 
-  /// Statusフィルタビルダー（selectと同じ）
-  SelectFilterBuilder status() => SelectFilterBuilder(propertyName);
+  /// Statusフィルタビルダー
+  StatusFilterBuilder status() => StatusFilterBuilder(propertyName);
 
   /// 日付フィルタビルダー
   DateFilterBuilder date() => DateFilterBuilder(propertyName);
@@ -153,9 +153,19 @@ class SelectFilterBuilder {
         filter: PropertyFilter.selectEquals(value),
       );
 
+  Filter equalsAny(List<String> values) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.selectEqualsAny(values),
+      );
+
   Filter doesNotEqual(String value) => Filter.property(
         name: propertyName,
         filter: PropertyFilter.selectDoesNotEqual(value),
+      );
+
+  Filter doesNotEqualAny(List<String> values) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.selectDoesNotEqualAny(values),
       );
 
   Filter isEmpty() => Filter.property(
@@ -169,6 +179,42 @@ class SelectFilterBuilder {
       );
 }
 
+/// Statusフィルタビルダー
+class StatusFilterBuilder {
+  const StatusFilterBuilder(this.propertyName);
+  final String propertyName;
+
+  Filter equals(String value) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.statusEquals(value),
+      );
+
+  Filter equalsAny(List<String> values) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.statusEqualsAny(values),
+      );
+
+  Filter doesNotEqual(String value) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.statusDoesNotEqual(value),
+      );
+
+  Filter doesNotEqualAny(List<String> values) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.statusDoesNotEqualAny(values),
+      );
+
+  Filter isEmpty() => Filter.property(
+        name: propertyName,
+        filter: const PropertyFilter.statusIsEmpty(),
+      );
+
+  Filter isNotEmpty() => Filter.property(
+        name: propertyName,
+        filter: const PropertyFilter.statusIsNotEmpty(),
+      );
+}
+
 /// MultiSelectフィルタビルダー
 class MultiSelectFilterBuilder {
   const MultiSelectFilterBuilder(this.propertyName);
@@ -179,9 +225,19 @@ class MultiSelectFilterBuilder {
         filter: PropertyFilter.multiSelectContains(value),
       );
 
+  Filter containsAny(List<String> values) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.multiSelectContainsAny(values),
+      );
+
   Filter doesNotContain(String value) => Filter.property(
         name: propertyName,
         filter: PropertyFilter.multiSelectDoesNotContain(value),
+      );
+
+  Filter doesNotContainAny(List<String> values) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.multiSelectDoesNotContainAny(values),
       );
 
   Filter isEmpty() => Filter.property(
@@ -264,6 +320,20 @@ class DateFilterBuilder {
         name: propertyName,
         filter: const PropertyFilter.dateNextYear(),
       );
+
+  Filter today() => equals('today');
+
+  Filter tomorrow() => equals('tomorrow');
+
+  Filter yesterday() => equals('yesterday');
+
+  Filter oneWeekAgo() => equals('one_week_ago');
+
+  Filter oneWeekFromNow() => equals('one_week_from_now');
+
+  Filter oneMonthAgo() => equals('one_month_ago');
+
+  Filter oneMonthFromNow() => equals('one_month_from_now');
 }
 
 /// Peopleフィルタビルダー
@@ -276,10 +346,14 @@ class PeopleFilterBuilder {
         filter: PropertyFilter.peopleContains(userId),
       );
 
+  Filter containsMe() => contains('me');
+
   Filter doesNotContain(String userId) => Filter.property(
         name: propertyName,
         filter: PropertyFilter.peopleDoesNotContain(userId),
       );
+
+  Filter doesNotContainMe() => doesNotContain('me');
 
   Filter isEmpty() => Filter.property(
         name: propertyName,

--- a/test/query_dsl_test.dart
+++ b/test/query_dsl_test.dart
@@ -39,6 +39,28 @@ void main() {
       });
     });
 
+    test('multi-value select and status filters generate correct JSON', () {
+      final selectFilter = 'Priority'.property.select().equalsAny([
+        'Low',
+        'Medium',
+      ]);
+      final statusFilter = 'Status'.property.status().doesNotEqualAny(['Done']);
+
+      expect(selectFilter.toJson(), {
+        'property': 'Priority',
+        'select': {
+          'equals': ['Low', 'Medium'],
+        },
+      });
+
+      expect(statusFilter.toJson(), {
+        'property': 'Status',
+        'status': {
+          'does_not_equal': ['Done'],
+        },
+      });
+    });
+
     test('date filter generates correct JSON', () {
       final filter = 'Due Date'.property.date().after('2025-10-05');
 
@@ -128,12 +150,35 @@ void main() {
       });
     });
 
+    test('multi-value multi-select filter', () {
+      final filter = 'Tags'.property.multiSelect().containsAny([
+        'Important',
+        'Urgent',
+      ]);
+
+      expect(filter.toJson(), {
+        'property': 'Tags',
+        'multi_select': {
+          'contains': ['Important', 'Urgent'],
+        },
+      });
+    });
+
     test('people filter', () {
       final filter = 'Assignee'.property.people().contains('user-id-123');
 
       expect(filter.toJson(), {
         'property': 'Assignee',
         'people': {'contains': 'user-id-123'},
+      });
+    });
+
+    test('people me filter', () {
+      final filter = 'Assignee'.property.people().containsMe();
+
+      expect(filter.toJson(), {
+        'property': 'Assignee',
+        'people': {'contains': 'me'},
       });
     });
 
@@ -161,6 +206,15 @@ void main() {
       expect(filter.toJson(), {
         'property': 'Created',
         'date': {'past_week': {}},
+      });
+    });
+
+    test('relative date value filter', () {
+      final filter = 'Due Date'.property.date().oneWeekFromNow();
+
+      expect(filter.toJson(), {
+        'property': 'Due Date',
+        'date': {'equals': 'one_week_from_now'},
       });
     });
   });


### PR DESCRIPTION
## Summary
- Add multi-value helpers for select, status, and multi-select filters
- Add people `me` filter helpers
- Add relative date filter helpers and value-based date operators
- Extend Query DSL tests for the new Notion filter shapes

## Verification
- `dart analyze`
- `dart test test/query_dsl_test.dart`