### PR TITLE
feat(query): add formula, rollup, timestamp, verification, unique_id filters

### DIFF
--- a/lib/src/query/filter.dart
+++ b/lib/src/query/filter.dart
@@ -447,16 +447,14 @@ sealed class PropertyFilter with _$PropertyFilter {
   // ============================================
 
   /// Verification status filter. Valid statuses: `verified`, `expired`, `none`.
-  const factory PropertyFilter.verification(String status) =
-      VerificationFilter;
+  const factory PropertyFilter.verification(String status) = VerificationFilter;
 
   // ============================================
   // Unique ID filters
   // ============================================
 
   /// Unique ID equals.
-  const factory PropertyFilter.uniqueIdEquals(int value) =
-      UniqueIdEqualsFilter;
+  const factory PropertyFilter.uniqueIdEquals(int value) = UniqueIdEqualsFilter;
 
   /// Unique ID does not equal.
   const factory PropertyFilter.uniqueIdDoesNotEqual(int value) =

--- a/lib/src/query/filter.dart
+++ b/lib/src/query/filter.dart
@@ -89,11 +89,43 @@ sealed class Filter with _$Filter {
     required PropertyFilter filter,
   }) = PropertyFilterCondition;
 
+  /// Timestamp filter on the entry's `created_time`.
+  ///
+  /// Timestamp filters do not take a property name. Pass a date condition
+  /// such as [PropertyFilter.dateOnOrBefore] or [PropertyFilter.datePastWeek].
+  ///
+  /// Example:
+  /// ```dart
+  /// Filter.createdTime(PropertyFilter.dateOnOrBefore('2022-10-13'))
+  /// ```
+  const factory Filter.createdTime(PropertyFilter date) = CreatedTimeFilter;
+
+  /// Timestamp filter on the entry's `last_edited_time`.
+  ///
+  /// Timestamp filters do not take a property name. Pass a date condition
+  /// such as [PropertyFilter.dateAfter] or [PropertyFilter.dateIsNotEmpty].
+  const factory Filter.lastEditedTime(PropertyFilter date) =
+      LastEditedTimeFilter;
+
   /// Converts this filter to a JSON map for the Notion API.
   Map<String, dynamic> toJson() => when(
         and: (filters) => {'and': filters.map((f) => f.toJson()).toList()},
         or: (filters) => {'or': filters.map((f) => f.toJson()).toList()},
         property: (name, filter) => {'property': name, ...filter.toJson()},
+        createdTime: (date) {
+          final inner = date.toJson();
+          return {
+            'timestamp': 'created_time',
+            'created_time': inner['date'] ?? inner,
+          };
+        },
+        lastEditedTime: (date) {
+          final inner = date.toJson();
+          return {
+            'timestamp': 'last_edited_time',
+            'last_edited_time': inner['date'] ?? inner,
+          };
+        },
       );
 }
 
@@ -366,6 +398,86 @@ sealed class PropertyFilter with _$PropertyFilter {
   /// Relation is not empty - has any related pages.
   const factory PropertyFilter.relationIsNotEmpty() = RelationIsNotEmptyFilter;
 
+  // ============================================
+  // Checkbox (additional)
+  // ============================================
+
+  /// Checkbox does not equal - differs from the boolean value.
+  const factory PropertyFilter.checkboxDoesNotEqual(bool value) =
+      CheckboxDoesNotEqualFilter;
+
+  // ============================================
+  // Formula filters
+  // ============================================
+
+  /// Formula filter - applies a [condition] matching the formula's result type
+  /// (checkbox, date, number, or rich text).
+  ///
+  /// Example:
+  /// ```dart
+  /// PropertyFilter.formula(PropertyFilter.dateAfter('2021-05-10'))
+  /// ```
+  const factory PropertyFilter.formula(PropertyFilter condition) =
+      FormulaFilter;
+
+  // ============================================
+  // Rollup filters
+  // ============================================
+
+  /// Rollup filter against a number or date rollup value.
+  ///
+  /// Pass a number or date [condition], e.g.
+  /// `PropertyFilter.rollup(PropertyFilter.numberDoesNotEqual(42))`.
+  const factory PropertyFilter.rollup(PropertyFilter condition) = RollupFilter;
+
+  /// Rollup `any` - at least one rollup value matches [condition].
+  const factory PropertyFilter.rollupAny(PropertyFilter condition) =
+      RollupAnyFilter;
+
+  /// Rollup `every` - all rollup values match [condition].
+  const factory PropertyFilter.rollupEvery(PropertyFilter condition) =
+      RollupEveryFilter;
+
+  /// Rollup `none` - no rollup value matches [condition].
+  const factory PropertyFilter.rollupNone(PropertyFilter condition) =
+      RollupNoneFilter;
+
+  // ============================================
+  // Verification filters
+  // ============================================
+
+  /// Verification status filter. Valid statuses: `verified`, `expired`, `none`.
+  const factory PropertyFilter.verification(String status) =
+      VerificationFilter;
+
+  // ============================================
+  // Unique ID filters
+  // ============================================
+
+  /// Unique ID equals.
+  const factory PropertyFilter.uniqueIdEquals(int value) =
+      UniqueIdEqualsFilter;
+
+  /// Unique ID does not equal.
+  const factory PropertyFilter.uniqueIdDoesNotEqual(int value) =
+      UniqueIdDoesNotEqualFilter;
+
+  /// Unique ID greater than.
+  const factory PropertyFilter.uniqueIdGreaterThan(int value) =
+      UniqueIdGreaterThanFilter;
+
+  /// Unique ID less than.
+  const factory PropertyFilter.uniqueIdLessThan(int value) =
+      UniqueIdLessThanFilter;
+
+  /// Unique ID greater than or equal to.
+  const factory PropertyFilter.uniqueIdGreaterThanOrEqual(int value) =
+      UniqueIdGreaterThanOrEqualFilter;
+
+  /// Unique ID less than or equal to.
+  const factory PropertyFilter.uniqueIdLessThanOrEqual(int value) =
+      UniqueIdLessThanOrEqualFilter;
+
   /// Converts this property filter to a JSON map for the Notion API.
   Map<String, dynamic> toJson() => when(
         // テキスト系
@@ -560,6 +672,51 @@ sealed class PropertyFilter with _$PropertyFilter {
         },
         relationIsNotEmpty: () => {
           'relation': {'is_not_empty': true},
+        },
+
+        // チェックボックス（追加）
+        checkboxDoesNotEqual: (value) => {
+          'checkbox': {'does_not_equal': value},
+        },
+
+        // Formula
+        formula: (condition) => {'formula': condition.toJson()},
+
+        // Rollup
+        rollup: (condition) => {'rollup': condition.toJson()},
+        rollupAny: (condition) => {
+          'rollup': {'any': condition.toJson()},
+        },
+        rollupEvery: (condition) => {
+          'rollup': {'every': condition.toJson()},
+        },
+        rollupNone: (condition) => {
+          'rollup': {'none': condition.toJson()},
+        },
+
+        // Verification
+        verification: (status) => {
+          'verification': {'status': status},
+        },
+
+        // Unique ID
+        uniqueIdEquals: (value) => {
+          'unique_id': {'equals': value},
+        },
+        uniqueIdDoesNotEqual: (value) => {
+          'unique_id': {'does_not_equal': value},
+        },
+        uniqueIdGreaterThan: (value) => {
+          'unique_id': {'greater_than': value},
+        },
+        uniqueIdLessThan: (value) => {
+          'unique_id': {'less_than': value},
+        },
+        uniqueIdGreaterThanOrEqual: (value) => {
+          'unique_id': {'greater_than_or_equal_to': value},
+        },
+        uniqueIdLessThanOrEqual: (value) => {
+          'unique_id': {'less_than_or_equal_to': value},
         },
       );
 }

--- a/lib/src/query/filter_builder.dart
+++ b/lib/src/query/filter_builder.dart
@@ -38,6 +38,19 @@ class PropertyFilterBuilder {
 
   /// Relationフィルタビルダー
   RelationFilterBuilder relation() => RelationFilterBuilder(propertyName);
+
+  /// Unique IDフィルタビルダー
+  UniqueIdFilterBuilder uniqueId() => UniqueIdFilterBuilder(propertyName);
+
+  /// Verificationフィルタビルダー
+  VerificationFilterBuilder verification() =>
+      VerificationFilterBuilder(propertyName);
+
+  /// Formulaフィルタビルダー
+  FormulaFilterBuilder formula() => FormulaFilterBuilder(propertyName);
+
+  /// Rollupフィルタビルダー
+  RollupFilterBuilder rollup() => RollupFilterBuilder(propertyName);
 }
 
 /// テキスト系フィルタビルダー
@@ -140,6 +153,11 @@ class CheckboxFilterBuilder {
   Filter equals(bool value) => Filter.property(
         name: propertyName,
         filter: PropertyFilter.checkboxEquals(value),
+      );
+
+  Filter doesNotEqual(bool value) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.checkboxDoesNotEqual(value),
       );
 }
 
@@ -406,6 +424,145 @@ class RelationFilterBuilder {
         name: propertyName,
         filter: const PropertyFilter.relationIsNotEmpty(),
       );
+}
+
+/// Unique IDフィルタビルダー
+class UniqueIdFilterBuilder {
+  const UniqueIdFilterBuilder(this.propertyName);
+  final String propertyName;
+
+  Filter equals(int value) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.uniqueIdEquals(value),
+      );
+
+  Filter doesNotEqual(int value) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.uniqueIdDoesNotEqual(value),
+      );
+
+  Filter greaterThan(int value) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.uniqueIdGreaterThan(value),
+      );
+
+  Filter lessThan(int value) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.uniqueIdLessThan(value),
+      );
+
+  Filter greaterThanOrEqual(int value) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.uniqueIdGreaterThanOrEqual(value),
+      );
+
+  Filter lessThanOrEqual(int value) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.uniqueIdLessThanOrEqual(value),
+      );
+}
+
+/// Verificationフィルタビルダー
+class VerificationFilterBuilder {
+  const VerificationFilterBuilder(this.propertyName);
+  final String propertyName;
+
+  Filter status(String status) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.verification(status),
+      );
+
+  Filter verified() => status('verified');
+
+  Filter expired() => status('expired');
+
+  Filter none() => status('none');
+}
+
+/// Formulaフィルタビルダー
+///
+/// フォーミュラの計算結果型に対応する内側の条件を指定する。
+class FormulaFilterBuilder {
+  const FormulaFilterBuilder(this.propertyName);
+  final String propertyName;
+
+  /// 任意の結果型条件（[condition]）でフォーミュラ結果を絞り込む。
+  Filter matches(PropertyFilter condition) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.formula(condition),
+      );
+}
+
+/// Rollupフィルタビルダー
+class RollupFilterBuilder {
+  const RollupFilterBuilder(this.propertyName);
+  final String propertyName;
+
+  /// number/date ロールアップ値への直接条件。
+  Filter matches(PropertyFilter condition) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.rollup(condition),
+      );
+
+  /// 少なくとも1つのロールアップ値が [condition] に一致。
+  Filter any(PropertyFilter condition) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.rollupAny(condition),
+      );
+
+  /// すべてのロールアップ値が [condition] に一致。
+  Filter every(PropertyFilter condition) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.rollupEvery(condition),
+      );
+
+  /// どのロールアップ値も [condition] に一致しない。
+  Filter none(PropertyFilter condition) => Filter.property(
+        name: propertyName,
+        filter: PropertyFilter.rollupNone(condition),
+      );
+}
+
+/// タイムスタンプフィルタビルダー（`created_time` / `last_edited_time`）。
+///
+/// タイムスタンプフィルタはプロパティ名を取らない。日付条件を渡す。
+///
+/// 例:
+/// ```dart
+/// TimestampFilter.createdTime.onOrBefore('2022-10-13');
+/// ```
+enum TimestampFilter {
+  /// `created_time` を対象とするタイムスタンプフィルタ。
+  createdTime,
+
+  /// `last_edited_time` を対象とするタイムスタンプフィルタ。
+  lastEditedTime;
+
+  Filter _wrap(PropertyFilter date) => this == TimestampFilter.createdTime
+      ? Filter.createdTime(date)
+      : Filter.lastEditedTime(date);
+
+  Filter equals(String date) => _wrap(PropertyFilter.dateEquals(date));
+
+  Filter before(String date) => _wrap(PropertyFilter.dateBefore(date));
+
+  Filter after(String date) => _wrap(PropertyFilter.dateAfter(date));
+
+  Filter onOrBefore(String date) => _wrap(PropertyFilter.dateOnOrBefore(date));
+
+  Filter onOrAfter(String date) => _wrap(PropertyFilter.dateOnOrAfter(date));
+
+  Filter pastWeek() => _wrap(const PropertyFilter.datePastWeek());
+
+  Filter pastMonth() => _wrap(const PropertyFilter.datePastMonth());
+
+  Filter pastYear() => _wrap(const PropertyFilter.datePastYear());
+
+  Filter nextWeek() => _wrap(const PropertyFilter.dateNextWeek());
+
+  Filter nextMonth() => _wrap(const PropertyFilter.dateNextMonth());
+
+  Filter nextYear() => _wrap(const PropertyFilter.dateNextYear());
 }
 
 /// String拡張（フィルタ用）

--- a/test/query_dsl_test.dart
+++ b/test/query_dsl_test.dart
@@ -349,10 +349,8 @@ void main() {
           .property
           .rollup()
           .every(const PropertyFilter.numberGreaterThan(3));
-      final noneFilter = 'Scores'
-          .property
-          .rollup()
-          .none(const PropertyFilter.numberEquals(0));
+      final noneFilter =
+          'Scores'.property.rollup().none(const PropertyFilter.numberEquals(0));
 
       expect(anyFilter.toJson(), {
         'property': 'Related tasks',
@@ -418,8 +416,7 @@ void main() {
     });
 
     test('timestamp filters omit the property name', () {
-      final created =
-          TimestampFilter.createdTime.onOrBefore('2022-10-13');
+      final created = TimestampFilter.createdTime.onOrBefore('2022-10-13');
       final edited = TimestampFilter.lastEditedTime.pastWeek();
 
       expect(created.toJson(), {

--- a/test/query_dsl_test.dart
+++ b/test/query_dsl_test.dart
@@ -315,4 +315,141 @@ void main() {
       });
     });
   });
+
+  group('Filter DSL - additional filter types', () {
+    test('checkbox does_not_equal generates correct JSON', () {
+      final filter = 'Done'.property.checkbox().doesNotEqual(true);
+
+      expect(filter.toJson(), {
+        'property': 'Done',
+        'checkbox': {'does_not_equal': true},
+      });
+    });
+
+    test('formula filter wraps the result-type condition', () {
+      final filter = 'One month deadline'
+          .property
+          .formula()
+          .matches(const PropertyFilter.dateAfter('2021-05-10'));
+
+      expect(filter.toJson(), {
+        'property': 'One month deadline',
+        'formula': {
+          'date': {'after': '2021-05-10'},
+        },
+      });
+    });
+
+    test('rollup any/every/none generate correct JSON', () {
+      final anyFilter = 'Related tasks'
+          .property
+          .rollup()
+          .any(const PropertyFilter.textContains('Migrate data source'));
+      final everyFilter = 'Scores'
+          .property
+          .rollup()
+          .every(const PropertyFilter.numberGreaterThan(3));
+      final noneFilter = 'Scores'
+          .property
+          .rollup()
+          .none(const PropertyFilter.numberEquals(0));
+
+      expect(anyFilter.toJson(), {
+        'property': 'Related tasks',
+        'rollup': {
+          'any': {
+            'rich_text': {'contains': 'Migrate data source'},
+          },
+        },
+      });
+      expect(everyFilter.toJson(), {
+        'property': 'Scores',
+        'rollup': {
+          'every': {
+            'number': {'greater_than': 3.0},
+          },
+        },
+      });
+      expect(noneFilter.toJson(), {
+        'property': 'Scores',
+        'rollup': {
+          'none': {
+            'number': {'equals': 0.0},
+          },
+        },
+      });
+    });
+
+    test('rollup direct number/date condition generates correct JSON', () {
+      final filter = 'Total estimated working days'
+          .property
+          .rollup()
+          .matches(const PropertyFilter.numberDoesNotEqual(42));
+
+      expect(filter.toJson(), {
+        'property': 'Total estimated working days',
+        'rollup': {
+          'number': {'does_not_equal': 42.0},
+        },
+      });
+    });
+
+    test('verification filter generates correct JSON', () {
+      final filter = 'verification'.property.verification().verified();
+
+      expect(filter.toJson(), {
+        'property': 'verification',
+        'verification': {'status': 'verified'},
+      });
+    });
+
+    test('unique_id filters generate correct JSON', () {
+      final equalsFilter = 'ID'.property.uniqueId().equals(42);
+      final rangeFilter = 'ID'.property.uniqueId().greaterThanOrEqual(1);
+
+      expect(equalsFilter.toJson(), {
+        'property': 'ID',
+        'unique_id': {'equals': 42},
+      });
+      expect(rangeFilter.toJson(), {
+        'property': 'ID',
+        'unique_id': {'greater_than_or_equal_to': 1},
+      });
+    });
+
+    test('timestamp filters omit the property name', () {
+      final created =
+          TimestampFilter.createdTime.onOrBefore('2022-10-13');
+      final edited = TimestampFilter.lastEditedTime.pastWeek();
+
+      expect(created.toJson(), {
+        'timestamp': 'created_time',
+        'created_time': {'on_or_before': '2022-10-13'},
+      });
+      expect(edited.toJson(), {
+        'timestamp': 'last_edited_time',
+        'last_edited_time': {'past_week': <String, dynamic>{}},
+      });
+    });
+
+    test('timestamp filter can be combined inside compound filters', () {
+      final filter = Filter.and([
+        TimestampFilter.createdTime.after('2022-01-01'),
+        'ID'.property.uniqueId().lessThan(100),
+      ]);
+
+      expect(filter.toJson(), {
+        'and': [
+          {
+            'timestamp': 'created_time',
+            'created_time': {'after': '2022-01-01'},
+          },
+          {
+            'property': 'ID',
+            'unique_id': {'less_than': 100},
+          },
+        ],
+      });
+    });
+  });
 }


### PR DESCRIPTION
## 概要

Query DSL に不足していた Notion data source フィルタ条件型を追加します。公式仕様（`doc/filter-data-source-entries.md`）で定義されているが未実装だった型を、JSON 形状を 1 対 1 で照合して実装しました。

Closes #36

## 追加した内容

| 種別 | 内容 | 生成される JSON |
|------|------|------|
| **checkbox** | `does_not_equal`（従来は `equals` のみ） | `{"checkbox":{"does_not_equal":true}}` |
| **formula** | 結果型（checkbox/date/number/rich_text）の内側条件をラップ | `{"formula":{"date":{"after":"..."}}}` |
| **rollup** | `any`/`every`/`none` 集約 + number/date 直接条件 | `{"rollup":{"any":{...}}}` |
| **timestamp** | `created_time` / `last_edited_time`（プロパティ名なし） | `{"timestamp":"created_time","created_time":{...}}` |
| **verification** | `verified` / `expired` / `none` | `{"verification":{"status":"verified"}}` |
| **unique_id** | equals / does_not_equal / 大小比較（数値） | `{"unique_id":{"equals":42}}` |

## API 例

```dart
// formula
'Deadline'.property.formula().matches(PropertyFilter.dateAfter('2021-05-10'));

// rollup
'Related tasks'.property.rollup().any(PropertyFilter.textContains('Migrate'));

// timestamp (プロパティ名を取らない)
TimestampFilter.createdTime.onOrBefore('2022-10-13');

// unique_id
'ID'.property.uniqueId().greaterThanOrEqual(1);

// verification
'verification'.property.verification().verified();
```

## 実装メモ

- `PropertyFilter`（freezed sealed union）に新ファクトリと `toJson` 分岐を追加。`formula`/`rollup` はネストした `PropertyFilter` を再帰的に再利用するため、内側条件の JSON がそのまま正しい形状になります。
- `timestamp` フィルタはプロパティ名を持たない特殊形のため、`Filter` 側に `Filter.createdTime` / `Filter.lastEditedTime` を追加しました（公式仕様: プロパティ名を渡すと API がエラーを返す）。
- 既存の `rich_text` キー方式（title/url/email も含む text 系）は公式 doc と一致しているため変更していません。

## テスト

- `test/query_dsl_test.dart` に各フィルタの round-trip JSON 検証を追加（複合フィルタ内での timestamp 使用も検証）。
- `dart analyze` クリーン / 全テストパス（334 件、追加分含む）。

🤖 監査に基づく自動メンテナンス PR です。

https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1)_