### PR TITLE
feat(errors): surface Notion error code and request_id; map more status codes

### DIFF
--- a/lib/src/client/http_client.dart
+++ b/lib/src/client/http_client.dart
@@ -180,8 +180,7 @@ class NotionHttpClient {
   /// Extracts the Notion request id from the `x-notion-request-id` header,
   /// falling back to a `request_id` field in the response body.
   String? _extractRequestId(DioException error) {
-    final header =
-        error.response?.headers['x-notion-request-id']?.firstOrNull;
+    final header = error.response?.headers['x-notion-request-id']?.firstOrNull;
     if (header != null) {
       return header;
     }

--- a/lib/src/client/http_client.dart
+++ b/lib/src/client/http_client.dart
@@ -68,40 +68,15 @@ class NotionHttpClient {
   void _handleError(DioException error, ErrorInterceptorHandler handler) {
     final statusCode = error.response?.statusCode;
     final message = _extractErrorMessage(error);
+    final code = _extractErrorCode(error);
+    final requestId = _extractRequestId(error);
 
-    NotionException exception;
-
-    switch (statusCode) {
-      case 400:
-        exception = ValidationException(
-          message ?? 'Invalid request',
-          statusCode: statusCode,
-        );
-        break;
-      case 401:
-        exception = AuthenticationException(
-          message ?? 'Authentication failed',
-          statusCode: statusCode,
-        );
-        break;
-      case 404:
-        exception = NotFoundException(
-          message ?? 'Resource not found',
-          statusCode: statusCode,
-        );
-        break;
-      case 429:
-        exception = RateLimitException(
-          message ?? 'Rate limit exceeded',
-          statusCode: statusCode,
-        );
-        break;
-      default:
-        exception = NotionException(
-          message ?? 'An error occurred',
-          statusCode: statusCode,
-        );
-    }
+    final exception = _buildException(
+      statusCode: statusCode,
+      message: message,
+      code: code,
+      requestId: requestId,
+    );
 
     handler.reject(
       DioException(
@@ -113,6 +88,77 @@ class NotionHttpClient {
     );
   }
 
+  /// Maps an HTTP [statusCode] to the most specific [NotionException] subtype,
+  /// propagating the Notion error [code] and [requestId].
+  NotionException _buildException({
+    int? statusCode,
+    String? message,
+    String? code,
+    String? requestId,
+  }) {
+    switch (statusCode) {
+      case 400:
+        return ValidationException(
+          message ?? 'Invalid request',
+          statusCode: statusCode,
+          code: code,
+          requestId: requestId,
+        );
+      case 401:
+        return AuthenticationException(
+          message ?? 'Authentication failed',
+          statusCode: statusCode,
+          code: code,
+          requestId: requestId,
+        );
+      case 403:
+        return RestrictedResourceException(
+          message ?? 'Restricted resource',
+          statusCode: statusCode,
+          code: code,
+          requestId: requestId,
+        );
+      case 404:
+        return NotFoundException(
+          message ?? 'Resource not found',
+          statusCode: statusCode,
+          code: code,
+          requestId: requestId,
+        );
+      case 409:
+        return ConflictException(
+          message ?? 'Conflict error',
+          statusCode: statusCode,
+          code: code,
+          requestId: requestId,
+        );
+      case 429:
+        return RateLimitException(
+          message ?? 'Rate limit exceeded',
+          statusCode: statusCode,
+          code: code,
+          requestId: requestId,
+        );
+      case 500:
+      case 502:
+      case 503:
+      case 504:
+        return ServerException(
+          message ?? 'Server error',
+          statusCode: statusCode,
+          code: code,
+          requestId: requestId,
+        );
+      default:
+        return NotionException(
+          message ?? 'An error occurred',
+          statusCode: statusCode,
+          code: code,
+          requestId: requestId,
+        );
+    }
+  }
+
   String? _extractErrorMessage(DioException error) {
     final response = error.response;
     if (response?.data is Map) {
@@ -120,6 +166,30 @@ class NotionHttpClient {
       return data['message'] as String?;
     }
     return error.message;
+  }
+
+  /// Extracts the machine-readable Notion error code from the response body.
+  String? _extractErrorCode(DioException error) {
+    final data = error.response?.data;
+    if (data is Map && data['code'] is String) {
+      return data['code'] as String;
+    }
+    return null;
+  }
+
+  /// Extracts the Notion request id from the `x-notion-request-id` header,
+  /// falling back to a `request_id` field in the response body.
+  String? _extractRequestId(DioException error) {
+    final header =
+        error.response?.headers['x-notion-request-id']?.firstOrNull;
+    if (header != null) {
+      return header;
+    }
+    final data = error.response?.data;
+    if (data is Map && data['request_id'] is String) {
+      return data['request_id'] as String;
+    }
+    return null;
   }
 
   /// Makes a GET request to the given [path] with rate limiting.

--- a/lib/src/utils/exceptions.dart
+++ b/lib/src/utils/exceptions.dart
@@ -1,7 +1,17 @@
 /// Base exception for all Notion API errors.
 class NotionException implements Exception {
   /// Creates a new [NotionException].
-  NotionException(this.message, {this.statusCode});
+  ///
+  /// [code] is the machine-readable Notion error code (e.g. `validation_error`,
+  /// `object_not_found`) extracted from the response body.
+  /// [requestId] is the value of the `x-notion-request-id` response header,
+  /// useful when reporting issues to Notion support.
+  NotionException(
+    this.message, {
+    this.statusCode,
+    this.code,
+    this.requestId,
+  });
 
   /// The error message.
   final String message;
@@ -9,54 +19,149 @@ class NotionException implements Exception {
   /// The HTTP status code, if available.
   final int? statusCode;
 
+  /// The machine-readable Notion error code, if available.
+  ///
+  /// See https://developers.notion.com/reference/status-codes for the full
+  /// list (e.g. `validation_error`, `restricted_resource`, `conflict_error`).
+  final String? code;
+
+  /// The Notion request id (`x-notion-request-id` header), if available.
+  final String? requestId;
+
+  /// A detail suffix including code, status, and request id when present.
+  String get details {
+    final parts = <String>[];
+    if (code != null) {
+      parts.add('code: $code');
+    }
+    if (statusCode != null) {
+      parts.add('status: $statusCode');
+    }
+    if (requestId != null) {
+      parts.add('request_id: $requestId');
+    }
+    return parts.isEmpty ? '' : ' (${parts.join(', ')})';
+  }
+
   @override
-  String toString() => 'NotionException: $message';
+  String toString() => 'NotionException: $message$details';
 }
 
-/// Exception thrown when the API rate limit is exceeded.
+/// Exception thrown when the API rate limit is exceeded (HTTP 429).
 class RateLimitException extends NotionException {
-  RateLimitException(super.message, {super.statusCode});
+  RateLimitException(
+    super.message, {
+    super.statusCode,
+    super.code,
+    super.requestId,
+  });
 
   @override
-  String toString() => 'RateLimitException: $message';
+  String toString() => 'RateLimitException: $message$details';
 }
 
-/// Exception thrown when authentication fails.
+/// Exception thrown when authentication fails (HTTP 401).
 class AuthenticationException extends NotionException {
-  AuthenticationException(super.message, {super.statusCode});
+  AuthenticationException(
+    super.message, {
+    super.statusCode,
+    super.code,
+    super.requestId,
+  });
 
   @override
-  String toString() => 'AuthenticationException: $message';
+  String toString() => 'AuthenticationException: $message$details';
 }
 
-/// Exception thrown when a requested resource is not found.
+/// Exception thrown when the bearer token lacks permission (HTTP 403).
+class RestrictedResourceException extends NotionException {
+  RestrictedResourceException(
+    super.message, {
+    super.statusCode,
+    super.code,
+    super.requestId,
+  });
+
+  @override
+  String toString() => 'RestrictedResourceException: $message$details';
+}
+
+/// Exception thrown when a requested resource is not found (HTTP 404).
 class NotFoundException extends NotionException {
-  NotFoundException(super.message, {super.statusCode});
+  NotFoundException(
+    super.message, {
+    super.statusCode,
+    super.code,
+    super.requestId,
+  });
 
   @override
-  String toString() => 'NotFoundException: $message';
+  String toString() => 'NotFoundException: $message$details';
 }
 
-/// Exception thrown when the request is invalid.
+/// Exception thrown when the request is invalid (HTTP 400).
 class ValidationException extends NotionException {
-  ValidationException(super.message, {super.statusCode});
+  ValidationException(
+    super.message, {
+    super.statusCode,
+    super.code,
+    super.requestId,
+  });
 
   @override
-  String toString() => 'ValidationException: $message';
+  String toString() => 'ValidationException: $message$details';
+}
+
+/// Exception thrown when the transaction conflicts with the current state
+/// (HTTP 409, `conflict_error`).
+class ConflictException extends NotionException {
+  ConflictException(
+    super.message, {
+    super.statusCode,
+    super.code,
+    super.requestId,
+  });
+
+  @override
+  String toString() => 'ConflictException: $message$details';
+}
+
+/// Exception thrown when Notion encounters a server-side error
+/// (HTTP 500/502/503/504).
+class ServerException extends NotionException {
+  ServerException(
+    super.message, {
+    super.statusCode,
+    super.code,
+    super.requestId,
+  });
+
+  @override
+  String toString() => 'ServerException: $message$details';
 }
 
 /// Exception thrown when a template is not found.
 class TemplateNotFoundException extends NotionException {
-  TemplateNotFoundException(super.message, {super.statusCode});
+  TemplateNotFoundException(
+    super.message, {
+    super.statusCode,
+    super.code,
+    super.requestId,
+  });
 
   @override
-  String toString() => 'TemplateNotFoundException: $message';
+  String toString() => 'TemplateNotFoundException: $message$details';
 }
 
 /// Exception thrown when a template is invalid or cannot be used.
 class InvalidTemplateException extends NotionException {
-  InvalidTemplateException(super.message, {super.statusCode});
+  InvalidTemplateException(
+    super.message, {
+    super.statusCode,
+    super.code,
+    super.requestId,
+  });
 
   @override
-  String toString() => 'InvalidTemplateException: $message';
+  String toString() => 'InvalidTemplateException: $message$details';
 }

--- a/test/exceptions_test.dart
+++ b/test/exceptions_test.dart
@@ -1,0 +1,167 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:notion_dart_kit/notion_dart_kit.dart';
+import 'package:notion_dart_kit/src/client/http_client.dart';
+import 'package:test/test.dart';
+
+/// A minimal [HttpClientAdapter] that returns a canned JSON error response so
+/// the client's error interceptor can be exercised without real network I/O.
+class _StubErrorAdapter implements HttpClientAdapter {
+  _StubErrorAdapter({
+    required this.statusCode,
+    required this.body,
+    this.requestId,
+  });
+
+  final int statusCode;
+  final Map<String, dynamic> body;
+  final String? requestId;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<dynamic>? cancelFuture,
+  ) async {
+    return ResponseBody.fromString(
+      jsonEncode(body),
+      statusCode,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+        if (requestId != null) 'x-notion-request-id': [requestId!],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+NotionHttpClient _clientReturning({
+  required int statusCode,
+  required Map<String, dynamic> body,
+  String? requestId,
+}) {
+  final dio = Dio()
+    ..httpClientAdapter = _StubErrorAdapter(
+      statusCode: statusCode,
+      body: body,
+      requestId: requestId,
+    );
+  return NotionHttpClient(token: 'test_token', dio: dio);
+}
+
+void main() {
+  group('NotionException fields and formatting', () {
+    test('carries code and requestId and surfaces them in toString', () {
+      final ex = NotionException(
+        'Something went wrong',
+        statusCode: 400,
+        code: 'validation_error',
+        requestId: 'req-123',
+      );
+
+      expect(ex.code, 'validation_error');
+      expect(ex.requestId, 'req-123');
+      expect(ex.statusCode, 400);
+      expect(
+        ex.toString(),
+        'NotionException: Something went wrong '
+        '(code: validation_error, status: 400, request_id: req-123)',
+      );
+    });
+
+    test('omits the detail suffix when no metadata is present', () {
+      expect(NotionException('boom').toString(), 'NotionException: boom');
+    });
+
+    test('subclasses thread code and requestId through super', () {
+      final ex = ConflictException(
+        'conflict',
+        statusCode: 409,
+        code: 'conflict_error',
+        requestId: 'req-9',
+      );
+      expect(ex, isA<NotionException>());
+      expect(ex.code, 'conflict_error');
+      expect(ex.requestId, 'req-9');
+      expect(ex.toString(), contains('ConflictException: conflict'));
+      expect(ex.toString(), contains('code: conflict_error'));
+    });
+  });
+
+  group('HTTP error mapping', () {
+    test('403 maps to RestrictedResourceException with code and requestId',
+        () async {
+      final client = _clientReturning(
+        statusCode: 403,
+        body: {
+          'object': 'error',
+          'status': 403,
+          'code': 'restricted_resource',
+          'message': 'Insufficient permissions.',
+        },
+        requestId: 'req-403',
+      );
+      addTearDown(client.close);
+
+      await expectLater(
+        client.get('/pages/abc'),
+        throwsA(
+          isA<RestrictedResourceException>()
+              .having((e) => e.code, 'code', 'restricted_resource')
+              .having((e) => e.statusCode, 'statusCode', 403)
+              .having((e) => e.requestId, 'requestId', 'req-403')
+              .having((e) => e.message, 'message', 'Insufficient permissions.'),
+        ),
+      );
+    });
+
+    test('409 maps to ConflictException', () async {
+      final client = _clientReturning(
+        statusCode: 409,
+        body: {
+          'object': 'error',
+          'code': 'conflict_error',
+          'message': 'Conflict occurred.',
+        },
+        requestId: 'req-409',
+      );
+      addTearDown(client.close);
+
+      await expectLater(
+        client.post('/pages'),
+        throwsA(
+          isA<ConflictException>()
+              .having((e) => e.code, 'code', 'conflict_error')
+              .having((e) => e.requestId, 'requestId', 'req-409'),
+        ),
+      );
+    });
+
+    test('falls back to request_id in the body when header is absent',
+        () async {
+      final client = _clientReturning(
+        statusCode: 400,
+        body: {
+          'object': 'error',
+          'code': 'validation_error',
+          'message': 'Bad request.',
+          'request_id': 'body-req-id',
+        },
+      );
+      addTearDown(client.close);
+
+      await expectLater(
+        client.patch('/pages/abc'),
+        throwsA(
+          isA<ValidationException>()
+              .having((e) => e.code, 'code', 'validation_error')
+              .having((e) => e.requestId, 'requestId', 'body-req-id'),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 概要

`NotionException` がデバッグ・サポートに不可欠な情報（Notion の error `code` と `x-notion-request-id`）を保持していなかった問題を解消し、status code → 例外型のマッピングを拡充します。

Closes #37

## 変更点

### `NotionException` の拡張（後方互換）
- `code`（String?）— 機械可読の Notion エラーコード（例: `validation_error`, `restricted_resource`, `conflict_error`）
- `requestId`（String?）— `x-notion-request-id` ヘッダ値（Notion サポートへの問い合わせに有用）
- `toString()` に `(code: …, status: …, request_id: …)` の詳細サフィックスを付与（メタデータが無い場合は従来通りのメッセージのみ）
- いずれも任意名前付き引数のため、既存の生成コードは影響を受けません

### status code マッピング拡充（`http_client.dart`）
| status | 例外型 | code 例 |
|--------|--------|---------|
| 400 | `ValidationException` | `validation_error` |
| 401 | `AuthenticationException` | `unauthorized` |
| **403** | **`RestrictedResourceException`**（新規） | `restricted_resource` |
| 404 | `NotFoundException` | `object_not_found` |
| **409** | **`ConflictException`**（新規） | `conflict_error` |
| 429 | `RateLimitException` | `rate_limited` |
| **500/502/503/504** | **`ServerException`**（新規） | `internal_server_error` 等 |

- レスポンスボディから `code` を抽出
- `x-notion-request-id` ヘッダ → 無ければボディの `request_id` をフォールバック抽出

## テスト

`test/exceptions_test.dart` を新規追加:
- 例外フィールド/`toString()` フォーマット、サブクラスの super スレッド
- 軽量な `HttpClientAdapter` スタブで実際の interceptor を通し、403→`RestrictedResourceException`、409→`ConflictException`、`request_id` のボディフォールバックを検証

`dart analyze` クリーン / 全テストパス。

## 根拠

`doc/errors.md`（公式ローカルコピー、status-codes 表）に基づくコードマッピング。

🤖 監査に基づく自動メンテナンス PR です。

https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1)_