### PR TITLE
feat(blocks): parse heading_4, audio, meeting_notes, tab block types

### DIFF
--- a/lib/src/models/block.dart
+++ b/lib/src/models/block.dart
@@ -68,6 +68,20 @@ class Block with _$Block {
     required BlockContent content,
   }) = _Heading3Block;
 
+  /// Heading 4 block
+  const factory Block.heading4({
+    required String id,
+    required Parent parent,
+    required DateTime createdTime,
+    required DateTime lastEditedTime,
+    required User createdBy,
+    required User lastEditedBy,
+    required bool hasChildren,
+    required bool archived,
+    required bool inTrash,
+    required BlockContent content,
+  }) = _Heading4Block;
+
   /// Bulleted list item block
   const factory Block.bulletedListItem({
     required String id,
@@ -436,6 +450,53 @@ class Block with _$Block {
     required String title,
   }) = _ChildDatabaseBlock;
 
+  /// Audio block
+  const factory Block.audio({
+    required String id,
+    required Parent parent,
+    required DateTime createdTime,
+    required DateTime lastEditedTime,
+    required User createdBy,
+    required User lastEditedBy,
+    required bool hasChildren,
+    required bool archived,
+    required bool inTrash,
+    required Map<String, dynamic> file,
+  }) = _AudioBlock;
+
+  /// Meeting notes block (renamed from `transcription` in API 2026-03-11).
+  ///
+  /// The payload schema is large and evolving, so it is preserved as a raw
+  /// map under [data].
+  const factory Block.meetingNotes({
+    required String id,
+    required Parent parent,
+    required DateTime createdTime,
+    required DateTime lastEditedTime,
+    required User createdBy,
+    required User lastEditedBy,
+    required bool hasChildren,
+    required bool archived,
+    required bool inTrash,
+    required Map<String, dynamic> data,
+  }) = _MeetingNotesBlock;
+
+  /// Tab block (API 2026-03-11).
+  ///
+  /// The payload schema is preserved as a raw map under [data].
+  const factory Block.tab({
+    required String id,
+    required Parent parent,
+    required DateTime createdTime,
+    required DateTime lastEditedTime,
+    required User createdBy,
+    required User lastEditedBy,
+    required bool hasChildren,
+    required bool archived,
+    required bool inTrash,
+    required Map<String, dynamic> data,
+  }) = _TabBlock;
+
   /// Unsupported block type
   const factory Block.unsupported({
     required String id,
@@ -523,6 +584,21 @@ class Block with _$Block {
           inTrash: inTrash,
           content: BlockContent.fromJson(
             json['heading_3'] as Map<String, dynamic>,
+          ),
+        );
+      case 'heading_4':
+        return Block.heading4(
+          id: id,
+          parent: parent,
+          createdTime: createdTime,
+          lastEditedTime: lastEditedTime,
+          createdBy: createdBy,
+          lastEditedBy: lastEditedBy,
+          hasChildren: hasChildren,
+          archived: archived,
+          inTrash: inTrash,
+          content: BlockContent.fromJson(
+            json['heading_4'] as Map<String, dynamic>,
           ),
         );
       case 'bulleted_list_item':
@@ -911,6 +987,49 @@ class Block with _$Block {
           inTrash: inTrash,
           title: childDbData['title'] as String,
         );
+      case 'audio':
+        return Block.audio(
+          id: id,
+          parent: parent,
+          createdTime: createdTime,
+          lastEditedTime: lastEditedTime,
+          createdBy: createdBy,
+          lastEditedBy: lastEditedBy,
+          hasChildren: hasChildren,
+          archived: archived,
+          inTrash: inTrash,
+          file: json['audio'] as Map<String, dynamic>,
+        );
+      // `transcription` was renamed to `meeting_notes` in API 2026-03-11.
+      // Accept both for backwards compatibility when reading responses.
+      case 'meeting_notes':
+      case 'transcription':
+        return Block.meetingNotes(
+          id: id,
+          parent: parent,
+          createdTime: createdTime,
+          lastEditedTime: lastEditedTime,
+          createdBy: createdBy,
+          lastEditedBy: lastEditedBy,
+          hasChildren: hasChildren,
+          archived: archived,
+          inTrash: inTrash,
+          data: (json['meeting_notes'] ?? json['transcription'])
+              as Map<String, dynamic>,
+        );
+      case 'tab':
+        return Block.tab(
+          id: id,
+          parent: parent,
+          createdTime: createdTime,
+          lastEditedTime: lastEditedTime,
+          createdBy: createdBy,
+          lastEditedBy: lastEditedBy,
+          hasChildren: hasChildren,
+          archived: archived,
+          inTrash: inTrash,
+          data: json['tab'] as Map<String, dynamic>,
+        );
       default:
         return Block.unsupported(
           id: id,
@@ -1031,6 +1150,32 @@ class Block with _$Block {
           'in_trash': inTrash,
           'type': 'heading_3',
           'heading_3': content.toJson(),
+        },
+        heading4: (
+          id,
+          parent,
+          createdTime,
+          lastEditedTime,
+          createdBy,
+          lastEditedBy,
+          hasChildren,
+          archived,
+          inTrash,
+          content,
+        ) =>
+            {
+          'object': 'block',
+          'id': id,
+          'parent': parent.toJson(),
+          'created_time': createdTime.toIso8601String(),
+          'last_edited_time': lastEditedTime.toIso8601String(),
+          'created_by': createdBy.toJson(),
+          'last_edited_by': lastEditedBy.toJson(),
+          'has_children': hasChildren,
+          'archived': archived,
+          'in_trash': inTrash,
+          'type': 'heading_4',
+          'heading_4': content.toJson(),
         },
         bulletedListItem: (
           id,
@@ -1735,6 +1880,84 @@ class Block with _$Block {
           'in_trash': inTrash,
           'type': 'child_database',
           'child_database': {'title': title},
+        },
+        audio: (
+          id,
+          parent,
+          createdTime,
+          lastEditedTime,
+          createdBy,
+          lastEditedBy,
+          hasChildren,
+          archived,
+          inTrash,
+          file,
+        ) =>
+            {
+          'object': 'block',
+          'id': id,
+          'parent': parent.toJson(),
+          'created_time': createdTime.toIso8601String(),
+          'last_edited_time': lastEditedTime.toIso8601String(),
+          'created_by': createdBy.toJson(),
+          'last_edited_by': lastEditedBy.toJson(),
+          'has_children': hasChildren,
+          'archived': archived,
+          'in_trash': inTrash,
+          'type': 'audio',
+          'audio': file,
+        },
+        meetingNotes: (
+          id,
+          parent,
+          createdTime,
+          lastEditedTime,
+          createdBy,
+          lastEditedBy,
+          hasChildren,
+          archived,
+          inTrash,
+          data,
+        ) =>
+            {
+          'object': 'block',
+          'id': id,
+          'parent': parent.toJson(),
+          'created_time': createdTime.toIso8601String(),
+          'last_edited_time': lastEditedTime.toIso8601String(),
+          'created_by': createdBy.toJson(),
+          'last_edited_by': lastEditedBy.toJson(),
+          'has_children': hasChildren,
+          'archived': archived,
+          'in_trash': inTrash,
+          'type': 'meeting_notes',
+          'meeting_notes': data,
+        },
+        tab: (
+          id,
+          parent,
+          createdTime,
+          lastEditedTime,
+          createdBy,
+          lastEditedBy,
+          hasChildren,
+          archived,
+          inTrash,
+          data,
+        ) =>
+            {
+          'object': 'block',
+          'id': id,
+          'parent': parent.toJson(),
+          'created_time': createdTime.toIso8601String(),
+          'last_edited_time': lastEditedTime.toIso8601String(),
+          'created_by': createdBy.toJson(),
+          'last_edited_by': lastEditedBy.toJson(),
+          'has_children': hasChildren,
+          'archived': archived,
+          'in_trash': inTrash,
+          'type': 'tab',
+          'tab': data,
         },
         unsupported: (
           id,

--- a/test/blocks_service_test.dart
+++ b/test/blocks_service_test.dart
@@ -411,6 +411,58 @@ void main() {
           __________,
         ) =>
             fail('Should be paragraph'),
+        heading4: (
+          _,
+          __,
+          ___,
+          ____,
+          _____,
+          ______,
+          _______,
+          ________,
+          _________,
+          __________,
+        ) =>
+            fail('Should be paragraph'),
+        audio: (
+          _,
+          __,
+          ___,
+          ____,
+          _____,
+          ______,
+          _______,
+          ________,
+          _________,
+          __________,
+        ) =>
+            fail('Should be paragraph'),
+        meetingNotes: (
+          _,
+          __,
+          ___,
+          ____,
+          _____,
+          ______,
+          _______,
+          ________,
+          _________,
+          __________,
+        ) =>
+            fail('Should be paragraph'),
+        tab: (
+          _,
+          __,
+          ___,
+          ____,
+          _____,
+          ______,
+          _______,
+          ________,
+          _________,
+          __________,
+        ) =>
+            fail('Should be paragraph'),
         unsupported:
             (_, __, ___, ____, _____, ______, _______, ________, _________) =>
                 fail('Should be paragraph'),
@@ -892,6 +944,58 @@ void main() {
             __________,
           ) =>
               false,
+          heading4: (
+            _,
+            __,
+            ___,
+            ____,
+            _____,
+            ______,
+            _______,
+            ________,
+            _________,
+            __________,
+          ) =>
+              false,
+          audio: (
+            _,
+            __,
+            ___,
+            ____,
+            _____,
+            ______,
+            _______,
+            ________,
+            _________,
+            __________,
+          ) =>
+              false,
+          meetingNotes: (
+            _,
+            __,
+            ___,
+            ____,
+            _____,
+            ______,
+            _______,
+            ________,
+            _________,
+            __________,
+          ) =>
+              false,
+          tab: (
+            _,
+            __,
+            ___,
+            ____,
+            _____,
+            ______,
+            _______,
+            ________,
+            _________,
+            __________,
+          ) =>
+              false,
           unsupported:
               (_, __, ___, ____, _____, ______, _______, ________, _________) =>
                   false,
@@ -1290,10 +1394,169 @@ void main() {
           __________,
         ) =>
             fail('Should be todo'),
+        heading4: (
+          _,
+          __,
+          ___,
+          ____,
+          _____,
+          ______,
+          _______,
+          ________,
+          _________,
+          __________,
+        ) =>
+            fail('Should be todo'),
+        audio: (
+          _,
+          __,
+          ___,
+          ____,
+          _____,
+          ______,
+          _______,
+          ________,
+          _________,
+          __________,
+        ) =>
+            fail('Should be todo'),
+        meetingNotes: (
+          _,
+          __,
+          ___,
+          ____,
+          _____,
+          ______,
+          _______,
+          ________,
+          _________,
+          __________,
+        ) =>
+            fail('Should be todo'),
+        tab: (
+          _,
+          __,
+          ___,
+          ____,
+          _____,
+          ______,
+          _______,
+          ________,
+          _________,
+          __________,
+        ) =>
+            fail('Should be todo'),
         unsupported:
             (_, __, ___, ____, _____, ______, _______, ________, _________) =>
                 fail('Should be todo'),
       );
+    });
+  });
+
+  group('Block Types added in API 2026-03-11', () {
+    Map<String, dynamic> base(String type, Map<String, dynamic> payload) => {
+          'object': 'block',
+          'id': 'b-$type',
+          'parent': {'type': 'page_id', 'page_id': 'page'},
+          'created_time': '2025-10-05T10:00:00.000Z',
+          'last_edited_time': '2025-10-05T10:00:00.000Z',
+          'created_by': {'object': 'user', 'id': 'user'},
+          'last_edited_by': {'object': 'user', 'id': 'user'},
+          'has_children': false,
+          'archived': false,
+          'in_trash': false,
+          'type': type,
+          type: payload,
+        };
+
+    test('heading_4 parses and round-trips', () {
+      final json = base('heading_4', {
+        'rich_text': [
+          {
+            'type': 'text',
+            'text': {'content': 'Section'},
+            'annotations': <String, dynamic>{},
+            'plain_text': 'Section',
+          },
+        ],
+        'color': 'default',
+        'is_toggleable': true,
+      });
+
+      final block = Block.fromJson(json);
+      // Parsed as a dedicated heading4 variant (not the unsupported fallback).
+      final isHeading4 = block.maybeWhen(
+        heading4: (
+          _,
+          __,
+          ___,
+          ____,
+          _____,
+          ______,
+          _______,
+          ________,
+          _________,
+          content,
+        ) =>
+            (content.isToggleable ?? false) && content.richText.length == 1,
+        orElse: () => false,
+      );
+      expect(isHeading4, true);
+
+      final out = block.toJson();
+      expect(out['type'], 'heading_4');
+      expect(out['heading_4'], isA<Map<String, dynamic>>());
+    });
+
+    test('audio parses and round-trips', () {
+      final json = base('audio', {
+        'type': 'external',
+        'external': {'url': 'https://example.com/a.mp3'},
+      });
+
+      final block = Block.fromJson(json);
+      final out = block.toJson();
+      expect(out['type'], 'audio');
+      expect(
+        ((out['audio'] as Map<String, dynamic>)['external']
+            as Map<String, dynamic>)['url'],
+        'https://example.com/a.mp3',
+      );
+    });
+
+    test('meeting_notes parses and round-trips', () {
+      final json = base('meeting_notes', {
+        'name': 'Standup',
+        'attendees': <String>[],
+      });
+
+      final block = Block.fromJson(json);
+      final out = block.toJson();
+      expect(out['type'], 'meeting_notes');
+      expect((out['meeting_notes'] as Map<String, dynamic>)['name'], 'Standup');
+    });
+
+    test('legacy transcription block is read as meeting_notes', () {
+      // Only the legacy `transcription` payload is present (no meeting_notes).
+      final json = base('transcription', {'name': 'Old transcript'});
+
+      final block = Block.fromJson(json);
+      final out = block.toJson();
+      // Always serialized using the new key.
+      expect(out['type'], 'meeting_notes');
+      expect(
+        (out['meeting_notes'] as Map<String, dynamic>)['name'],
+        'Old transcript',
+      );
+    });
+
+    test('tab parses and round-trips', () {
+      final json = base('tab', {'title': 'Overview'});
+
+      final block = Block.fromJson(json);
+      final out = block.toJson();
+      expect(out['type'], 'tab');
+      expect((out['tab'] as Map<String, dynamic>)['title'], 'Overview');
     });
   });
 }


### PR DESCRIPTION
## 概要

レスポンス解析で未対応だった（builder でのみ生成可能、または unsupported にフォールバックしていた）ブロック型を first-class 対応します。

Closes #38

## 追加した型

| 型 | 内容 |
|----|------|
| `heading_4` | `heading_1..3` と同等。`is_toggleable` 対応 |
| `audio` | file ベースのブロック |
| `meeting_notes` | API 2026-03-11 で `transcription` からリネーム。**旧 `transcription` ペイロードも後方互換で読み取り**、常に `meeting_notes` として再シリアライズ |
| `tab` | タブブロック |

`meeting_notes` と `tab` は仕様が大きく流動的なため、ペイロードを raw map（`data`）として保持します。未知のブロック型は従来どおり `unsupported` にフォールバックします。

## 後方互換

- `Block` は `@Freezed(toJson:false, fromJson:false)` の sealed union で、`toJson`/`fromJson` は手書きです。新 variant 追加に伴い、既存の網羅的な `Block.when()` 呼び出し箇所（テスト3箇所）に新ブランチを追加しました。
- 旧 `transcription` の読み取り互換を維持。

## テスト

`test/blocks_service_test.dart` に「Block Types added in API 2026-03-11」グループを追加（各型の round-trip、`transcription`→`meeting_notes` 互換読みを検証）。`dart analyze` クリーン / 全テストパス。

## 補足（スコープ外の既知事項）

`BlockContent` の freezed 生成 `toJson()` が camelCase キー（`richText` 等）を出力し、snake_case を意図した `BlockContentExtension.toJson` を shadow している既存の挙動を確認しました。本 PR のスコープ外のため変更していませんが、別途 issue 化を検討する価値があります（heading 系コンテンツの `Block.toJson` 出力に影響）。

🤖 監査に基づく自動メンテナンス PR です。

https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1)_