### PR TITLE
feat(models): add FileUpload complete_url and file_import_result fields

### DIFF
--- a/lib/src/models/file_upload.dart
+++ b/lib/src/models/file_upload.dart
@@ -12,6 +12,8 @@ class FileUpload {
     required this.contentLength,
     this.expiryTime,
     this.uploadUrl,
+    this.completeUrl,
+    this.fileImportResult,
   });
 
   factory FileUpload.fromJson(Map<String, dynamic> json) => FileUpload(
@@ -23,6 +25,8 @@ class FileUpload {
             ? null
             : DateTime.parse(json['expiry_time'] as String),
         uploadUrl: json['upload_url'] as String?,
+        completeUrl: json['complete_url'] as String?,
+        fileImportResult: json['file_import_result'] as Map<String, dynamic>?,
         archived: json['archived'] as bool,
         status: _parseStatus(json['status'] as String?),
         filename: json['filename'] as String,
@@ -36,6 +40,16 @@ class FileUpload {
   final DateTime lastEditedTime;
   final DateTime? expiryTime;
   final String? uploadUrl;
+
+  /// URL to complete a multi-part file upload. Only present for multi-part
+  /// uploads.
+  final String? completeUrl;
+
+  /// Details on the success or failure of importing a file from an external
+  /// URL. Only present for `external_url` uploads with a `failed` or
+  /// `uploaded` status.
+  final Map<String, dynamic>? fileImportResult;
+
   final bool archived;
   final FileUploadStatus status;
   final String filename;
@@ -49,6 +63,8 @@ class FileUpload {
         'last_edited_time': lastEditedTime.toIso8601String(),
         if (expiryTime != null) 'expiry_time': expiryTime!.toIso8601String(),
         'upload_url': uploadUrl,
+        if (completeUrl != null) 'complete_url': completeUrl,
+        if (fileImportResult != null) 'file_import_result': fileImportResult,
         'archived': archived,
         'status': status.name,
         'filename': filename,

--- a/test/file_uploads_service_test.dart
+++ b/test/file_uploads_service_test.dart
@@ -33,6 +33,57 @@ void main() {
       client.close();
     });
 
+    test('fromJson reads complete_url and file_import_result', () {
+      final upload = FileUpload.fromJson({
+        'object': 'file_upload',
+        'id': 'fu-1',
+        'created_time': '2026-01-01T00:00:00.000Z',
+        'last_edited_time': '2026-01-01T00:00:00.000Z',
+        'archived': false,
+        'status': 'uploaded',
+        'filename': 'photo.png',
+        'content_type': 'image/png',
+        'content_length': 1024,
+        'complete_url': 'https://api.notion.com/v1/file_uploads/fu-1/complete',
+        'file_import_result': {
+          'type': 'success',
+          'success': <String, dynamic>{},
+        },
+      });
+
+      expect(
+        upload.completeUrl,
+        'https://api.notion.com/v1/file_uploads/fu-1/complete',
+      );
+      expect(upload.fileImportResult, isA<Map<String, dynamic>>());
+      expect(upload.fileImportResult!['type'], 'success');
+
+      final json = upload.toJson();
+      expect(
+        json['complete_url'],
+        'https://api.notion.com/v1/file_uploads/fu-1/complete',
+      );
+      expect(json['file_import_result'], isA<Map<String, dynamic>>());
+    });
+
+    test('toJson omits new fields when absent', () {
+      final upload = FileUpload.fromJson({
+        'object': 'file_upload',
+        'id': 'fu-2',
+        'created_time': '2026-01-01T00:00:00.000Z',
+        'last_edited_time': '2026-01-01T00:00:00.000Z',
+        'archived': false,
+        'status': 'pending',
+        'filename': 'doc.pdf',
+        'content_type': 'application/pdf',
+        'content_length': 2048,
+      });
+
+      final json = upload.toJson();
+      expect(json.containsKey('complete_url'), false);
+      expect(json.containsKey('file_import_result'), false);
+    });
+
     test('create() validates required params for external_url', () async {
       final client = NotionClient(token: 'test_token');
       final svc = client.fileUploads;


### PR DESCRIPTION
## 概要

公式 File Upload オブジェクト（`doc/file-upload.md`）に存在するが `FileUpload` モデルに欠落していたフィールドを追加します。

Closes #39

## 追加フィールド

| フィールド | 型 | 説明 |
|-----------|-----|------|
| `completeUrl`（`complete_url`） | `String?` | マルチパートアップロードを完了するための URL |
| `fileImportResult`（`file_import_result`） | `Map<String, dynamic>?` | `external_url` インポートの成否詳細（`failed`/`uploaded` 時のみ） |

- いずれも任意フィールド（後方互換）
- `toJson` は値が無い場合キーを出力しません（既存出力を維持）

## テスト

`test/file_uploads_service_test.dart` に round-trip 検証と「フィールド非存在時の省略」検証を追加。`dart analyze` クリーン / 全テストパス。

🤖 監査に基づく自動メンテナンス PR です。

https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1)_