### PR TITLE
fix(blocks): serialize block content with snake_case Notion keys

### DIFF
--- a/lib/src/models/block_content.dart
+++ b/lib/src/models/block_content.dart
@@ -47,7 +47,11 @@ enum BlockColor {
 }
 
 /// Standard block content (paragraph, headings, lists, etc.)
-@freezed
+///
+/// `toJson` is intentionally disabled on the generated class so that the
+/// snake_case [BlockContentExtension.toJson] (matching the Notion API) is used
+/// instead of the json_serializable default, which would emit camelCase keys.
+@Freezed(toJson: false)
 class BlockContent with _$BlockContent {
   const factory BlockContent({
     @Default([]) List<RichText> richText,
@@ -72,7 +76,7 @@ class BlockContent with _$BlockContent {
 }
 
 /// To-do block content with checked state
-@freezed
+@Freezed(toJson: false)
 class ToDoContent with _$ToDoContent {
   const factory ToDoContent({
     @Default([]) List<RichText> richText,
@@ -97,7 +101,7 @@ class ToDoContent with _$ToDoContent {
 }
 
 /// Code block content with language
-@freezed
+@Freezed(toJson: false)
 class CodeContent with _$CodeContent {
   const factory CodeContent({
     @Default([]) List<RichText> richText,

--- a/test/block_content_test.dart
+++ b/test/block_content_test.dart
@@ -1,0 +1,62 @@
+import 'package:notion_dart_kit/notion_dart_kit.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BlockContent serialization uses snake_case Notion keys', () {
+    test('BlockContent.toJson emits rich_text / color / is_toggleable', () {
+      const content = BlockContent(isToggleable: true);
+      final json = content.toJson();
+
+      expect(json.containsKey('rich_text'), true);
+      expect(json.containsKey('color'), true);
+      expect(json['color'], 'default');
+      expect(json['is_toggleable'], true);
+      // Must NOT use the camelCase keys from the default json_serializable output.
+      expect(json.containsKey('richText'), false);
+      expect(json.containsKey('isToggleable'), false);
+    });
+
+    test('BlockContent.toJson omits is_toggleable when null', () {
+      const content = BlockContent(isToggleable: null);
+      expect(content.toJson().containsKey('is_toggleable'), false);
+    });
+
+    test('ToDoContent.toJson emits rich_text / color / checked', () {
+      const content = ToDoContent(checked: true);
+      final json = content.toJson();
+
+      expect(json.containsKey('rich_text'), true);
+      expect(json['checked'], true);
+      expect(json.containsKey('richText'), false);
+    });
+
+    test('CodeContent.toJson emits rich_text / caption / language', () {
+      const content = CodeContent(language: 'dart');
+      final json = content.toJson();
+
+      expect(json.containsKey('rich_text'), true);
+      expect(json.containsKey('caption'), true);
+      expect(json['language'], 'dart');
+    });
+
+    test('Block.toJson nests snake_case content for heading blocks', () {
+      final block = Block.heading1(
+        id: 'h1',
+        parent: const Parent.page(pageId: 'p'),
+        createdTime: DateTime.parse('2026-01-01T00:00:00.000Z'),
+        lastEditedTime: DateTime.parse('2026-01-01T00:00:00.000Z'),
+        createdBy: const User.person(id: 'u', person: PersonInfo()),
+        lastEditedBy: const User.person(id: 'u', person: PersonInfo()),
+        hasChildren: false,
+        archived: false,
+        inTrash: false,
+        content: const BlockContent(),
+      );
+
+      final heading = block.toJson()['heading_1'] as Map<String, dynamic>;
+      expect(heading.containsKey('rich_text'), true);
+      expect(heading.containsKey('is_toggleable'), true);
+      expect(heading.containsKey('richText'), false);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

`BlockContent` / `ToDoContent` / `CodeContent` は `@freezed` の生成 `toJson()`(camelCase: `richText`, `isToggleable` 等)が、snake_case を意図した `BlockContentExtension.toJson()` を **shadow** しており、`Block.toJson()` がコンテンツ系ブロック(paragraph / heading_1..4 / quote / toggle 等)で **Notion API が受け付けない不正なペイロード**を出力していました。

Closes #46

## 修正

3つのコンテンツクラスを `@Freezed(toJson: false)` にし、生成 `toJson` を無効化。これにより snake_case の拡張メソッドが正式な `toJson` になります。

| | 修正前(生成・誤) | 修正後(拡張・正) |
|---|---|---|
| BlockContent | `{richText, color, isToggleable}` | `{rich_text, color, is_toggleable}` |
| ToDoContent | `{richText, color, checked}` | `{rich_text, color, checked}` |
| CodeContent | `{richText, caption, language}` | `{rich_text, caption, language}` |

`fromJson` は変更なし。

## テスト

`test/block_content_test.dart` を新規追加し、各コンテンツの snake_case 出力と `Block.toJson()` のネスト(`heading_1` 内が snake_case)を検証。`dart analyze --fatal-infos` クリーン / 全テストパス(352)。

🤖 リサーチに基づく自動メンテナンス PR です。

https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1)_