### PR TITLE
fix(templates): align Template model with the official API shape; deprecate retrieveTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ void main() async {
 | Users | `me`, `retrieve`, `list` | Provides pagination-ready user listings and bot metadata access. |
 | Comments | `create`, `list`, `retrieve` | Create and fetch comments for pages/blocks; supports attachments and display name overrides. |
 | File Uploads | `create`, `sendBytes`, `sendFile`, `complete`, `retrieve`, `list` | Supports single-part, multi-part, and external URL uploads. |
-| Templates | `listTemplates`, `retrieveTemplate` | **NEW in v0.2.2**: List and retrieve templates from data sources; create pages from templates. |
+| Templates | `listTemplates` | List a data source's templates (`id`, `name`, `isDefault`); create pages from templates via `templateId`. |
 
 ## 🛡️ Resilience & Error Handling
 
@@ -436,19 +436,20 @@ for (final user in users.results) {
 }
 ```
 
-### Working with Templates (NEW in v0.2.2)
+### Working with Templates
 
-The Template API allows you to list templates from data sources and create pages using those templates:
+The Template API lets you list a data source's templates and create pages from
+them. The Notion API exposes templates with a minimal shape: `id`, `name`, and
+`isDefault`.
 
 ```dart
 // List all templates from a data source
 final templates = await client.templates.listTemplates('data_source_id');
 
 for (final template in templates.results) {
-  print('Template: ${template.title}');
-  print('Description: ${template.description}');
-  print('Created: ${template.createdTime}');
-  print('URL: ${template.url}');
+  print('Template: ${template.name}');
+  print('Id: ${template.id}');
+  print('Default: ${template.isDefault}');
 }
 
 // Handle pagination for large template lists
@@ -460,19 +461,13 @@ if (templates.hasMore) {
   );
 }
 
-// Retrieve a specific template
-final template = await client.templates.retrieveTemplate(
-  'data_source_id',
-  'template_id',
-);
-
-print('Template: ${template.title}');
-print('Created by: ${template.createdBy.name}');
-print('Last edited: ${template.lastEditedTime}');
+// Find the default template
+final defaultTemplate =
+    templates.results.where((t) => t.isDefault).toList();
 
 // Create a page from a template
 final pageFromTemplate = await client.pages.create(
-  parent: Parent.database('database_id'),
+  parent: const Parent.database(databaseId: 'database_id'),
   properties: {
     'Name': {
       'title': [
@@ -483,37 +478,20 @@ final pageFromTemplate = await client.pages.create(
       'select': {'name': 'Draft'}
     }
   },
-  templateId: template.id, // Use the template
+  templateId: templates.results.first.id, // Use the template
 );
 
 print('Created page: ${pageFromTemplate.id}');
 ```
 
+> Note: The Notion API does not provide a public endpoint to retrieve a single
+> template by id. Use `listTemplates` and filter the results.
+
 **Template API Features:**
 
 - ✅ List templates from data sources with pagination
-- ✅ Retrieve specific template details
 - ✅ Create pages using templates
-- ✅ Full type safety with Template model
-- ✅ Proper error handling for template operations
-- ✅ Backward compatibility with existing page creation
-
-**Error Handling:**
-
-```dart
-try {
-  final template = await client.templates.retrieveTemplate(
-    'data_source_id',
-    'nonexistent_template',
-  );
-} on TemplateNotFoundException catch (e) {
-  print('Template not found: ${e.message}');
-} on InvalidTemplateException catch (e) {
-  print('Invalid template: ${e.message}');
-} on NotionException catch (e) {
-  print('API error: ${e.message}');
-}
-```
+- ✅ Full type safety with the `Template` model (`id`, `name`, `isDefault`)
 
 ### Comments
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -103,7 +103,7 @@ void main() async {
 | Users | `me`, `retrieve`, `list` | ページネーション対応のユーザーリストとボットメタデータアクセスを提供します。 |
 | Comments | `create`, `list`, `retrieve` | ページ/ブロック上のコメント作成・取得。添付や表示名の上書きも対応。 |
 | File Uploads | `create`, `sendBytes`, `sendFile`, `complete`, `retrieve`, `list` | シングル/マルチパート/外部URLのアップロードに対応。 |
-| Templates | `listTemplates`, `retrieveTemplate` | **v0.2.2の新機能**: データソースからテンプレートを一覧・取得し、テンプレートからページを作成。 |
+| Templates | `listTemplates` | データソースのテンプレート(`id`、`name`、`isDefault`)を一覧し、`templateId` でページを作成。 |
 
 ## 🛡️ 回復力とエラーハンドリング
 
@@ -405,19 +405,18 @@ print('Upload status: ${uploaded.status}');
 // final done = await client.fileUploads.complete(session.id);
 ```
 
-### テンプレートの操作 (v0.2.2の新機能)
+### テンプレートの操作
 
-Template APIを使用して、データソースからテンプレートを一覧・取得し、テンプレートを使用してページを作成できます:
+Template APIを使用して、データソースのテンプレートを一覧し、テンプレートからページを作成できます。Notion APIのテンプレートは最小限の形状(`id`、`name`、`isDefault`)で返されます。
 
 ```dart
 // データソースからすべてのテンプレートを一覧
 final templates = await client.templates.listTemplates('data_source_id');
 
 for (final template in templates.results) {
-  print('テンプレート: ${template.title}');
-  print('説明: ${template.description}');
-  print('作成日: ${template.createdTime}');
-  print('URL: ${template.url}');
+  print('テンプレート: ${template.name}');
+  print('ID: ${template.id}');
+  print('デフォルト: ${template.isDefault}');
 }
 
 // 大きなテンプレートリストのページネーション処理
@@ -429,19 +428,13 @@ if (templates.hasMore) {
   );
 }
 
-// 特定のテンプレートを取得
-final template = await client.templates.retrieveTemplate(
-  'data_source_id',
-  'template_id',
-);
-
-print('テンプレート: ${template.title}');
-print('作成者: ${template.createdBy.name}');
-print('最終編集: ${template.lastEditedTime}');
+// デフォルトテンプレートを探す
+final defaultTemplate =
+    templates.results.where((t) => t.isDefault).toList();
 
 // テンプレートからページを作成
 final pageFromTemplate = await client.pages.create(
-  parent: Parent.database('database_id'),
+  parent: const Parent.database(databaseId: 'database_id'),
   properties: {
     'Name': {
       'title': [
@@ -452,37 +445,19 @@ final pageFromTemplate = await client.pages.create(
       'select': {'name': 'ドラフト'}
     }
   },
-  templateId: template.id, // テンプレートを使用
+  templateId: templates.results.first.id, // テンプレートを使用
 );
 
 print('作成されたページ: ${pageFromTemplate.id}');
 ```
 
+> 注: Notion APIには単一テンプレートをIDで取得する公開エンドポイントはありません。`listTemplates` で取得して絞り込んでください。
+
 **Template API機能:**
 
-- ✅ ページネーション付きでデータソースからテンプレートを一覧
-- ✅ 特定のテンプレートの詳細を取得
+- ✅ ページネーション付きでデータソースのテンプレートを一覧
 - ✅ テンプレートを使用してページを作成
-- ✅ Templateモデルによる完全な型安全性
-- ✅ テンプレート操作の適切なエラーハンドリング
-- ✅ 既存のページ作成との後方互換性
-
-**エラーハンドリング:**
-
-```dart
-try {
-  final template = await client.templates.retrieveTemplate(
-    'data_source_id',
-    'nonexistent_template',
-  );
-} on TemplateNotFoundException catch (e) {
-  print('テンプレートが見つかりません: ${e.message}');
-} on InvalidTemplateException catch (e) {
-  print('無効なテンプレート: ${e.message}');
-} on NotionException catch (e) {
-  print('API エラー: ${e.message}');
-}
-```
+- ✅ `Template` モデル(`id`、`name`、`isDefault`)による型安全性
 
 ### クエリ DSL (型安全フィルターとソート)
 

--- a/example/templates_example.dart
+++ b/example/templates_example.dart
@@ -1,12 +1,11 @@
 import 'package:notion_dart_kit/notion_dart_kit.dart';
 
-/// Example demonstrating the Template API functionality (NEW in v0.2.2)
+/// Example demonstrating the data source templates API.
 ///
 /// This example shows how to:
 /// - List templates from a data source
-/// - Retrieve specific template details
-/// - Create pages using templates
-/// - Handle template-related errors
+/// - Find the default template
+/// - Create a page using a template (via the `templateId` parameter)
 void main() async {
   // Initialize the Notion client
   final client = NotionClient(
@@ -29,23 +28,22 @@ Future<void> templatesExample(NotionClient client) async {
 
   print('🔍 Template API Examples\n');
 
-  // Example 1: List all templates from a data source
+  // Example 1: List all templates from a data source.
+  //
+  // Each template exposes only `id`, `name`, and `isDefault`.
   print('1. Listing templates from data source...');
   try {
     final templates = await client.templates.listTemplates(dataSourceId);
 
     print('Found ${templates.results.length} templates:');
     for (final template in templates.results) {
-      print('  📄 ${template.title}');
+      final marker = template.isDefault ? ' (default)' : '';
+      print('  📄 ${template.name}$marker');
       print('     ID: ${template.id}');
-      print('     Description: ${template.description ?? 'No description'}');
-      print('     Created: ${template.createdTime}');
-      print('     Archived: ${template.archived}');
-      print('     URL: ${template.url}');
       print('');
     }
 
-    // Handle pagination if there are more templates
+    // Handle pagination if there are more templates.
     if (templates.hasMore) {
       print('📄 Loading more templates...');
       final nextPage = await client.templates.listTemplates(
@@ -59,73 +57,59 @@ Future<void> templatesExample(NotionClient client) async {
     print('❌ Error listing templates: $e');
   }
 
-  print('\n' + '=' * 50 + '\n');
+  print('\n${'=' * 50}\n');
 
-  // Example 2: Retrieve a specific template
-  print('2. Retrieving specific template...');
+  // Example 2: Find the default template.
+  print('2. Finding the default template...');
   try {
-    // First, get a template ID from the list
     final templates = await client.templates.listTemplates(dataSourceId);
+    Template? defaultTemplate;
+    for (final t in templates.results) {
+      if (t.isDefault) {
+        defaultTemplate = t;
+        break;
+      }
+    }
 
-    if (templates.results.isNotEmpty) {
-      final templateId = templates.results.first.id;
-
-      final template = await client.templates.retrieveTemplate(
-        dataSourceId,
-        templateId,
-      );
-
-      print('📄 Template Details:');
-      print('   Title: ${template.title}');
-      print('   Description: ${template.description ?? 'No description'}');
-      print('   Created: ${template.createdTime}');
-      print('   Last edited: ${template.lastEditedTime}');
-      print('   Created by: ${template.createdBy.name ?? 'Unknown'}');
-      print('   Last edited by: ${template.lastEditedBy.name ?? 'Unknown'}');
-      print('   Archived: ${template.archived}');
-      print('   URL: ${template.url}');
+    if (defaultTemplate != null) {
+      print('📄 Default template: ${defaultTemplate.name} '
+          '(${defaultTemplate.id})');
     } else {
-      print('❌ No templates found in data source');
+      print('No default template configured for this data source.');
     }
   } catch (e) {
-    print('❌ Error retrieving template: $e');
+    print('❌ Error finding default template: $e');
   }
 
-  print('\n' + '=' * 50 + '\n');
+  print('\n${'=' * 50}\n');
 
-  // Example 3: Create a page using a template
+  // Example 3: Create a page using a template.
   print('3. Creating page from template...');
   try {
-    // Get the first available template
     final templates = await client.templates.listTemplates(dataSourceId);
 
     if (templates.results.isNotEmpty) {
       final template = templates.results.first;
+      print('📄 Using template: ${template.name}');
 
-      print('📄 Using template: ${template.title}');
-
-      // Create a page from the template
       final pageFromTemplate = await client.pages.create(
-        parent: Parent.database(databaseId),
+        parent: const Parent.database(databaseId: databaseId),
         properties: {
           'Name': {
             'title': [
               {
                 'text': {
-                  'content': 'Page created from ${template.title} template',
+                  'content': 'Page created from ${template.name} template',
                 },
               },
             ],
           },
-          // Add other properties as needed based on your database schema
         },
-        templateId: template.id, // This is the key - specify the template
+        templateId: template.id, // Apply the template on creation.
       );
 
       print('✅ Successfully created page from template!');
       print('   Page ID: ${pageFromTemplate.id}');
-      print('   Page URL: ${pageFromTemplate.url}');
-      print('   Created from template: ${template.title}');
     } else {
       print('❌ No templates available to create page from');
     }
@@ -133,86 +117,10 @@ Future<void> templatesExample(NotionClient client) async {
     print('❌ Error creating page from template: $e');
   }
 
-  print('\n' + '=' * 50 + '\n');
-
-  // Example 4: Error handling for template operations
-  print('4. Demonstrating error handling...');
-
-  // Template not found error
-  try {
-    await client.templates.retrieveTemplate(
-      dataSourceId,
-      'nonexistent_template_id',
-    );
-  } on TemplateNotFoundException catch (e) {
-    print('✅ Caught TemplateNotFoundException: ${e.message}');
-  } catch (e) {
-    print('❌ Unexpected error: $e');
-  }
-
-  // Invalid template error (when creating page)
-  try {
-    await client.pages.create(
-      parent: Parent.database(databaseId),
-      properties: {
-        'Name': {
-          'title': [
-            {
-              'text': {'content': 'Test page'},
-            },
-          ],
-        },
-      },
-      templateId: 'invalid_template_id',
-    );
-  } on InvalidTemplateException catch (e) {
-    print('✅ Caught InvalidTemplateException: ${e.message}');
-  } on TemplateNotFoundException catch (e) {
-    print('✅ Caught TemplateNotFoundException: ${e.message}');
-  } catch (e) {
-    print('❌ Unexpected error: $e');
-  }
-
-  print('\n' + '=' * 50 + '\n');
-
-  // Example 5: Pagination with custom page size
-  print('5. Pagination example with custom page size...');
-  try {
-    var cursor = null;
-    var pageNumber = 1;
-    const pageSize = 5;
-
-    do {
-      print('📄 Loading page $pageNumber (size: $pageSize)...');
-
-      final templates = await client.templates.listTemplates(
-        dataSourceId,
-        startCursor: cursor,
-        pageSize: pageSize,
-      );
-
-      print('   Found ${templates.results.length} templates on this page');
-      for (var i = 0; i < templates.results.length; i++) {
-        final template = templates.results[i];
-        print('   ${i + 1}. ${template.title}');
-      }
-
-      cursor = templates.nextCursor;
-      pageNumber++;
-
-      // Break after 3 pages to avoid infinite loop in example
-      if (pageNumber > 3) break;
-    } while (cursor != null);
-
-    print('✅ Pagination example completed');
-  } catch (e) {
-    print('❌ Error in pagination example: $e');
-  }
-
   print('\n🎉 Template API examples completed!');
 }
 
-/// Helper function to demonstrate template filtering and searching
+/// Helper demonstrating client-side template filtering.
 Future<void> templateSearchExample(
   NotionClient client,
   String dataSourceId,
@@ -222,27 +130,15 @@ Future<void> templateSearchExample(
   try {
     final templates = await client.templates.listTemplates(dataSourceId);
 
-    // Filter templates by title (client-side filtering)
+    // Filter templates by name (client-side filtering).
     final projectTemplates = templates.results
-        .where((template) => template.title.toLowerCase().contains('project'))
+        .where((template) => template.name.toLowerCase().contains('project'))
         .toList();
 
     print('Found ${projectTemplates.length} project-related templates:');
     for (final template in projectTemplates) {
-      print('  📄 ${template.title}');
+      print('  📄 ${template.name}');
     }
-
-    // Filter non-archived templates
-    final activeTemplates =
-        templates.results.where((template) => !template.archived).toList();
-
-    print('Found ${activeTemplates.length} active templates');
-
-    // Sort templates by creation date (newest first)
-    final sortedTemplates = List<Template>.from(templates.results)
-      ..sort((a, b) => b.createdTime.compareTo(a.createdTime));
-
-    print('Most recent template: ${sortedTemplates.first.title}');
   } catch (e) {
     print('❌ Error in template search: $e');
   }

--- a/lib/src/models/template.dart
+++ b/lib/src/models/template.dart
@@ -1,64 +1,38 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-import 'user.dart';
-
 part 'template.freezed.dart';
 
-/// Template object representing a template in a Notion data source
+/// A data source template object.
+///
+/// Returned by the
+/// [List data source templates](https://developers.notion.com/reference/list-data-source-templates)
+/// endpoint (`GET /v1/data_sources/{data_source_id}/templates`).
+///
+/// The Notion API returns only a minimal shape for templates: an [id], a
+/// display [name], and whether it is the data source's [isDefault] template.
 @Freezed(toJson: false, fromJson: false)
 class Template with _$Template {
   const factory Template({
-    /// Unique identifier for the template
+    /// Unique identifier for the template.
     required String id,
 
-    /// Title of the template
-    required String title,
+    /// Display name of the template.
+    required String name,
 
-    /// Date and time when this template was created
-    required DateTime createdTime,
-
-    /// Date and time when this template was last edited
-    required DateTime lastEditedTime,
-
-    /// User who created this template
-    required User createdBy,
-
-    /// User who last edited this template
-    required User lastEditedBy,
-
-    /// URL of the template
-    required String url,
-
-    /// Optional description of the template
-    String? description,
-
-    /// Whether the template is archived
-    @Default(false) bool archived,
+    /// Whether this template is the data source's default template.
+    @Default(false) bool isDefault,
   }) = _Template;
   const Template._();
 
   factory Template.fromJson(Map<String, dynamic> json) => Template(
         id: json['id'] as String,
-        title: json['title'] as String,
-        createdTime: DateTime.parse(json['created_time'] as String),
-        lastEditedTime: DateTime.parse(json['last_edited_time'] as String),
-        createdBy: User.fromJson(json['created_by'] as Map<String, dynamic>),
-        lastEditedBy:
-            User.fromJson(json['last_edited_by'] as Map<String, dynamic>),
-        url: json['url'] as String,
-        description: json['description'] as String?,
-        archived: json['archived'] as bool? ?? false,
+        name: json['name'] as String,
+        isDefault: json['is_default'] as bool? ?? false,
       );
 
   Map<String, dynamic> toJson() => {
         'id': id,
-        'title': title,
-        'created_time': createdTime.toIso8601String(),
-        'last_edited_time': lastEditedTime.toIso8601String(),
-        'created_by': createdBy.toJson(),
-        'last_edited_by': lastEditedBy.toJson(),
-        'url': url,
-        if (description != null) 'description': description,
-        'archived': archived,
+        'name': name,
+        'is_default': isDefault,
       };
 }

--- a/lib/src/services/templates_service.dart
+++ b/lib/src/services/templates_service.dart
@@ -2,10 +2,12 @@ import '../client/http_client.dart';
 import '../models/pagination.dart';
 import '../models/template.dart';
 
-/// Service for interacting with Notion Templates API
+/// Service for interacting with the Notion data source templates API.
 ///
-/// Provides methods to retrieve templates from data sources.
-/// Templates are predefined page structures that can be used to create new pages.
+/// Provides access to the
+/// [List data source templates](https://developers.notion.com/reference/list-data-source-templates)
+/// endpoint. Templates are predefined page structures that can be used to
+/// create new pages within a data source.
 class TemplatesService {
   TemplatesService(this._httpClient);
   final NotionHttpClient _httpClient;
@@ -52,21 +54,18 @@ class TemplatesService {
     return PaginatedList.fromJson(response, Template.fromJson);
   }
 
-  /// Retrieves a specific template by ID from a data source
+  /// Retrieves a specific template by ID from a data source.
   ///
-  /// [dataSourceId] - The ID of the data source
-  /// [templateId] - The ID of the template to retrieve
-  ///
-  /// Returns a [Template] object
-  ///
-  /// Example:
-  /// ```dart
-  /// final template = await client.templates.retrieveTemplate(
-  ///   'data_source_id',
-  ///   'template_id',
-  /// );
-  /// print('Template title: ${template.title}');
-  /// ```
+  /// **Deprecated:** The Notion API does not expose a public endpoint to
+  /// retrieve a single template by id (only [listTemplates] exists). This
+  /// method calls `GET /data_sources/{id}/templates/{template_id}`, which is
+  /// not part of the documented API and will fail at runtime. It is kept for
+  /// backwards compatibility and will be removed in a future major version.
+  /// Use [listTemplates] and filter the results instead.
+  @Deprecated(
+    'No public Notion endpoint exists for retrieving a single template by id. '
+    'Use listTemplates instead. This will be removed in a future major version.',
+  )
   Future<Template> retrieveTemplate(
     String dataSourceId,
     String templateId,

--- a/test/notion_client_templates_test.dart
+++ b/test/notion_client_templates_test.dart
@@ -43,15 +43,13 @@ void main() {
     });
 
     group('Template API workflow', () {
-      test('should support complete template workflow', () {
-        // This test verifies that the client supports the complete template workflow:
+      test('should support template workflow', () {
+        // This test verifies that the client supports the template workflow:
         // 1. List templates from a data source
-        // 2. Retrieve a specific template
-        // 3. Create a page using a template
+        // 2. Create a page using a template
 
         // Verify that the necessary methods exist
         expect(client.templates.listTemplates, isA<Function>());
-        expect(client.templates.retrieveTemplate, isA<Function>());
         expect(client.pages.create, isA<Function>());
       });
     });

--- a/test/template_test.dart
+++ b/test/template_test.dart
@@ -3,150 +3,50 @@ import 'package:test/test.dart';
 
 void main() {
   group('Template', () {
-    test('should serialize and deserialize correctly', () {
+    test('should deserialize the official template shape', () {
       final json = {
         'id': 'template_123',
-        'title': 'Project Template',
-        'description': 'A template for new projects',
-        'created_time': '2023-01-01T00:00:00.000Z',
-        'last_edited_time': '2023-01-02T00:00:00.000Z',
-        'created_by': {
-          'object': 'user',
-          'id': 'user_123',
-          'type': 'person',
-          'person': {'email': 'test@example.com'},
-          'name': 'Test User',
-          'avatar_url': null,
-        },
-        'last_edited_by': {
-          'object': 'user',
-          'id': 'user_456',
-          'type': 'person',
-          'person': {'email': 'editor@example.com'},
-          'name': 'Editor User',
-          'avatar_url': null,
-        },
-        'url': 'https://notion.so/template_123',
-        'archived': false,
+        'name': 'Project Template',
+        'is_default': true,
       };
 
       final template = Template.fromJson(json);
 
       expect(template.id, equals('template_123'));
-      expect(template.title, equals('Project Template'));
-      expect(template.description, equals('A template for new projects'));
-      expect(
-        template.createdTime,
-        equals(DateTime.parse('2023-01-01T00:00:00.000Z')),
-      );
-      expect(
-        template.lastEditedTime,
-        equals(DateTime.parse('2023-01-02T00:00:00.000Z')),
-      );
-      expect(template.createdBy.id, equals('user_123'));
-      expect(template.lastEditedBy.id, equals('user_456'));
-      expect(template.url, equals('https://notion.so/template_123'));
-      expect(template.archived, equals(false));
-
-      final serialized = template.toJson();
-      expect(serialized['id'], equals('template_123'));
-      expect(serialized['title'], equals('Project Template'));
-      expect(serialized['description'], equals('A template for new projects'));
-      expect(serialized['archived'], equals(false));
+      expect(template.name, equals('Project Template'));
+      expect(template.isDefault, isTrue);
     });
 
-    test('should handle null description', () {
-      final json = {
-        'id': 'template_123',
-        'title': 'Simple Template',
-        'created_time': '2023-01-01T00:00:00.000Z',
-        'last_edited_time': '2023-01-02T00:00:00.000Z',
-        'created_by': {
-          'object': 'user',
-          'id': 'user_123',
-          'type': 'person',
-          'person': {'email': 'test@example.com'},
-          'name': 'Test User',
-          'avatar_url': null,
-        },
-        'last_edited_by': {
-          'object': 'user',
-          'id': 'user_456',
-          'type': 'person',
-          'person': {'email': 'editor@example.com'},
-          'name': 'Editor User',
-          'avatar_url': null,
-        },
-        'url': 'https://notion.so/template_123',
-        'archived': false,
-      };
+    test('should default is_default to false when absent', () {
+      final template = Template.fromJson({
+        'id': 'template_456',
+        'name': 'Simple Template',
+      });
 
-      final template = Template.fromJson(json);
-
-      expect(template.description, isNull);
-      expect(template.title, equals('Simple Template'));
+      expect(template.isDefault, isFalse);
+      expect(template.name, equals('Simple Template'));
     });
 
-    test('should handle archived template', () {
-      final json = {
-        'id': 'template_archived',
-        'title': 'Archived Template',
-        'created_time': '2023-01-01T00:00:00.000Z',
-        'last_edited_time': '2023-01-02T00:00:00.000Z',
-        'created_by': {
-          'object': 'user',
-          'id': 'user_123',
-          'type': 'person',
-          'person': {'email': 'test@example.com'},
-          'name': 'Test User',
-          'avatar_url': null,
-        },
-        'last_edited_by': {
-          'object': 'user',
-          'id': 'user_456',
-          'type': 'person',
-          'person': {'email': 'editor@example.com'},
-          'name': 'Editor User',
-          'avatar_url': null,
-        },
-        'url': 'https://notion.so/template_archived',
-        'archived': true,
-      };
+    test('should serialize back to snake_case', () {
+      const template = Template(
+        id: 'template_789',
+        name: 'New Template',
+        isDefault: true,
+      );
 
-      final template = Template.fromJson(json);
-
-      expect(template.archived, equals(true));
-      expect(template.id, equals('template_archived'));
+      expect(template.toJson(), {
+        'id': 'template_789',
+        'name': 'New Template',
+        'is_default': true,
+      });
     });
 
     test('should create template with factory constructor', () {
-      const createdBy = User.person(
-        id: 'user_123',
-        person: PersonInfo(email: 'test@example.com'),
-        name: 'Test User',
-      );
-
-      const lastEditedBy = User.person(
-        id: 'user_456',
-        person: PersonInfo(email: 'editor@example.com'),
-        name: 'Editor User',
-      );
-
-      final template = Template(
-        id: 'template_new',
-        title: 'New Template',
-        description: 'A newly created template',
-        createdTime: DateTime.parse('2023-01-01T00:00:00.000Z'),
-        lastEditedTime: DateTime.parse('2023-01-02T00:00:00.000Z'),
-        createdBy: createdBy,
-        lastEditedBy: lastEditedBy,
-        url: 'https://notion.so/template_new',
-      );
+      const template = Template(id: 'template_new', name: 'New Template');
 
       expect(template.id, equals('template_new'));
-      expect(template.title, equals('New Template'));
-      expect(template.description, equals('A newly created template'));
-      expect(template.archived, equals(false));
+      expect(template.name, equals('New Template'));
+      expect(template.isDefault, isFalse);
     });
   });
 }

--- a/test/templates_service_test.dart
+++ b/test/templates_service_test.dart
@@ -24,56 +24,8 @@ void main() {
           'object': 'list',
           'type': 'template',
           'results': [
-            {
-              'id': 'template_1',
-              'title': 'Template 1',
-              'description': 'First template',
-              'created_time': '2023-01-01T00:00:00.000Z',
-              'last_edited_time': '2023-01-02T00:00:00.000Z',
-              'created_by': {
-                'object': 'user',
-                'id': 'user_123',
-                'type': 'person',
-                'person': {'email': 'test@example.com'},
-                'name': 'Test User',
-                'avatar_url': null,
-              },
-              'last_edited_by': {
-                'object': 'user',
-                'id': 'user_456',
-                'type': 'person',
-                'person': {'email': 'editor@example.com'},
-                'name': 'Editor User',
-                'avatar_url': null,
-              },
-              'url': 'https://notion.so/template_1',
-              'archived': false,
-            },
-            {
-              'id': 'template_2',
-              'title': 'Template 2',
-              'description': 'Second template',
-              'created_time': '2023-01-01T00:00:00.000Z',
-              'last_edited_time': '2023-01-02T00:00:00.000Z',
-              'created_by': {
-                'object': 'user',
-                'id': 'user_123',
-                'type': 'person',
-                'person': {'email': 'test@example.com'},
-                'name': 'Test User',
-                'avatar_url': null,
-              },
-              'last_edited_by': {
-                'object': 'user',
-                'id': 'user_456',
-                'type': 'person',
-                'person': {'email': 'editor@example.com'},
-                'name': 'Editor User',
-                'avatar_url': null,
-              },
-              'url': 'https://notion.so/template_2',
-              'archived': false,
-            },
+            {'id': 'template_1', 'name': 'Template 1', 'is_default': true},
+            {'id': 'template_2', 'name': 'Template 2', 'is_default': false},
           ],
           'next_cursor': null,
           'has_more': false,
@@ -87,9 +39,10 @@ void main() {
 
         expect(result.results, hasLength(2));
         expect(result.results[0].id, equals('template_1'));
-        expect(result.results[0].title, equals('Template 1'));
+        expect(result.results[0].name, equals('Template 1'));
+        expect(result.results[0].isDefault, isTrue);
         expect(result.results[1].id, equals('template_2'));
-        expect(result.results[1].title, equals('Template 2'));
+        expect(result.results[1].isDefault, isFalse);
         expect(result.hasMore, equals(false));
         expect(result.nextCursor, isNull);
 
@@ -192,61 +145,6 @@ void main() {
       });
     });
 
-    group('retrieveTemplate', () {
-      test('should return specific template', () async {
-        const dataSourceId = 'data_source_123';
-        const templateId = 'template_456';
-
-        final mockResponse = {
-          'id': templateId,
-          'title': 'Specific Template',
-          'description': 'A specific template',
-          'created_time': '2023-01-01T00:00:00.000Z',
-          'last_edited_time': '2023-01-02T00:00:00.000Z',
-          'created_by': {
-            'object': 'user',
-            'id': 'user_123',
-            'type': 'person',
-            'person': {'email': 'test@example.com'},
-            'name': 'Test User',
-            'avatar_url': null,
-          },
-          'last_edited_by': {
-            'object': 'user',
-            'id': 'user_456',
-            'type': 'person',
-            'person': {'email': 'editor@example.com'},
-            'name': 'Editor User',
-            'avatar_url': null,
-          },
-          'url': 'https://notion.so/$templateId',
-          'archived': false,
-        };
-
-        when(
-          mockHttpClient.get(
-            '/data_sources/$dataSourceId/templates/$templateId',
-          ),
-        ).thenAnswer((_) async => mockResponse);
-
-        final result = await templatesService.retrieveTemplate(
-          dataSourceId,
-          templateId,
-        );
-
-        expect(result.id, equals(templateId));
-        expect(result.title, equals('Specific Template'));
-        expect(result.description, equals('A specific template'));
-        expect(result.archived, equals(false));
-
-        verify(
-          mockHttpClient.get(
-            '/data_sources/$dataSourceId/templates/$templateId',
-          ),
-        ).called(1);
-      });
-    });
-
     group('error handling', () {
       test('should propagate HTTP client errors', () async {
         const dataSourceId = 'data_source_123';
@@ -258,22 +156,6 @@ void main() {
         expect(
           () => templatesService.listTemplates(dataSourceId),
           throwsA(isA<NotionException>()),
-        );
-      });
-
-      test('should propagate template not found errors', () async {
-        const dataSourceId = 'data_source_123';
-        const templateId = 'nonexistent_template';
-
-        when(
-          mockHttpClient.get(
-            '/data_sources/$dataSourceId/templates/$templateId',
-          ),
-        ).thenThrow(TemplateNotFoundException('Template not found'));
-
-        expect(
-          () => templatesService.retrieveTemplate(dataSourceId, templateId),
-          throwsA(isA<TemplateNotFoundException>()),
         );
       });
     });


### PR DESCRIPTION
## 概要

公式 notion-sdk-js(v5.12.0, API 2026-03-11)のソースで照合した結果に基づき、`Template` モデルを**実際のAPI形状**に修正します。

Closes #40

## リサーチ結果(権威ある照合)

`src/api-endpoints/data-sources.ts` を確認:

- `GET /data_sources/{data_source_id}/templates`(`listDataSourceTemplates`)は**実在する公開エンドポイント** → 維持。
- テンプレートオブジェクトの実形状は **`{ id, name, is_default }` の3フィールドのみ**。
- **単一テンプレートをIDで取得するエンドポイントは存在しない**。

> ※ 調査開始時は「templates 自体が捏造の疑い」でしたが、SDK照合で list は正当と判明。誤って廃止せず済みました。

## 変更

- **`Template` モデル**: `{ id, name, isDefault }` に修正(旧 `title`/`url`/`createdTime`/`createdBy`/`archived` 等は実レスポンスと不一致でパース不能だった)。snake_case の `fromJson`/`toJson`。
- **`retrieveTemplate`**: 公開エンドポイントが存在しないため `@Deprecated` 化(将来のメジャーで削除予定)。`listTemplates` は維持。
- テスト(`template_test` / `templates_service_test` / `notion_client_templates_test`)を実形状に更新し、deprecated メンバーの同パッケージ参照を除去。
- `example/templates_example.dart` を新形状に書き換え(ついでに既存の `Parent.database` 誤用も修正)。
- `README.md` / `README_ja.md` のテンプレート節を更新。

## 破壊的変更について

`Template` の公開フィールドが変わります。ただし旧フィールドは実APIレスポンスをパースできず**従来から機能していなかった**ため、実質的なバグ修正です。リリース時は CHANGELOG での明記を推奨します。

## テスト

`dart analyze --fatal-infos` クリーン / `dart format` クリーン / 全テストパス(345)。

🤖 リサーチに基づく自動メンテナンス PR です。

https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1)_