### PR TITLE
test(views): pin ViewsService endpoint shapes; document verified spec

### DIFF
--- a/doc/working-with-views.md
+++ b/doc/working-with-views.md
@@ -1,0 +1,30 @@
+# Views API (verified endpoint reference)
+
+The official Notion developer docs for Views are not mirrored in this `doc/`
+folder. This note records the endpoint shapes that `ViewsService`
+(`lib/src/services/views_service.dart`) implements, verified against the
+official JavaScript SDK
+[`makenotion/notion-sdk-js`](https://github.com/makenotion/notion-sdk-js)
+v5.12.0 (which targets API version `2026-03-11`),
+`src/api-endpoints/views.ts`.
+
+| Operation | Method | Path | Notes |
+| --- | --- | --- | --- |
+| List views | `GET` | `/v1/views` | Query params: `database_id` **or** `data_source_id` (exactly one), `start_cursor`, `page_size` |
+| Retrieve view | `GET` | `/v1/views/{view_id}` | |
+| Create view | `POST` | `/v1/views` | Body includes `data_source_id`, `name`, `type`, and one of `database_id` / `view_id` / `create_database` |
+| Update view | `PATCH` | `/v1/views/{view_id}` | |
+| Delete view | `DELETE` | `/v1/views/{view_id}` | |
+| Create view query | `POST` | `/v1/views/{view_id}/queries` | Returns a cached query result page |
+| Get view query results | `GET` | `/v1/views/{view_id}/queries/{query_id}` | Supports `start_cursor`, `page_size` |
+| Delete view query | `DELETE` | `/v1/views/{view_id}/queries/{query_id}` | |
+
+Notes:
+
+- The official SDK does **not** define `duplicate` or `properties` endpoints
+  for views (some third-party summaries incorrectly list them).
+- View queries are a create/paginate/delete lifecycle (cached queries), not a
+  single synchronous `POST /views/{id}/query`.
+
+`test/views_service_test.dart` pins these method + path shapes to guard against
+regressions.

--- a/test/views_service_test.dart
+++ b/test/views_service_test.dart
@@ -1,0 +1,140 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:notion_dart_kit/notion_dart_kit.dart';
+import 'package:notion_dart_kit/src/client/http_client.dart';
+import 'package:notion_dart_kit/src/services/views_service.dart';
+import 'package:test/test.dart';
+
+/// Records the most recent request and returns a canned response that satisfies
+/// View / PaginatedList<View> / ViewQuery parsers.
+class _RecordingAdapter implements HttpClientAdapter {
+  RequestOptions? last;
+
+  static final Map<String, dynamic> _body = {
+    'object': 'list',
+    'id': 'view_1',
+    'name': 'Grid',
+    'type': 'table',
+    'results': <dynamic>[],
+    'has_more': false,
+    'next_cursor': null,
+  };
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<dynamic>? cancelFuture,
+  ) async {
+    last = options;
+    return ResponseBody.fromString(
+      jsonEncode(_body),
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+void main() {
+  // These tests pin the ViewsService endpoint shapes against the official
+  // Notion API (verified against makenotion/notion-sdk-js v5.12.0,
+  // API version 2026-03-11).
+  group('ViewsService endpoint shapes', () {
+    late _RecordingAdapter adapter;
+    late NotionHttpClient httpClient;
+    late ViewsService views;
+
+    setUp(() {
+      adapter = _RecordingAdapter();
+      final dio = Dio()..httpClientAdapter = adapter;
+      httpClient = NotionHttpClient(token: 'test_token', dio: dio);
+      views = ViewsService(httpClient);
+    });
+
+    tearDown(() => httpClient.close());
+
+    test('list -> GET /views with database_id query', () async {
+      await views.list(databaseId: 'db_1', pageSize: 10);
+      expect(adapter.last!.method, 'GET');
+      expect(adapter.last!.path, '/views');
+      expect(adapter.last!.queryParameters['database_id'], 'db_1');
+      expect(adapter.last!.queryParameters['page_size'], 10);
+    });
+
+    test('list -> GET /views with data_source_id query', () async {
+      await views.list(dataSourceId: 'ds_1');
+      expect(adapter.last!.method, 'GET');
+      expect(adapter.last!.path, '/views');
+      expect(adapter.last!.queryParameters['data_source_id'], 'ds_1');
+    });
+
+    test('list requires exactly one parent', () async {
+      await expectLater(views.list(), throwsArgumentError);
+      await expectLater(
+        views.list(databaseId: 'db', dataSourceId: 'ds'),
+        throwsArgumentError,
+      );
+    });
+
+    test('retrieve -> GET /views/{id}', () async {
+      await views.retrieve('view_1');
+      expect(adapter.last!.method, 'GET');
+      expect(adapter.last!.path, '/views/view_1');
+    });
+
+    test('create -> POST /views with body', () async {
+      await views.create(
+        dataSourceId: 'ds_1',
+        name: 'My View',
+        type: 'table',
+        databaseId: 'db_1',
+      );
+      expect(adapter.last!.method, 'POST');
+      expect(adapter.last!.path, '/views');
+      final body = adapter.last!.data as Map<String, dynamic>;
+      expect(body['data_source_id'], 'ds_1');
+      expect(body['name'], 'My View');
+      expect(body['type'], 'table');
+      expect(body['database_id'], 'db_1');
+    });
+
+    test('update -> PATCH /views/{id}', () async {
+      await views.update('view_1', name: 'Renamed');
+      expect(adapter.last!.method, 'PATCH');
+      expect(adapter.last!.path, '/views/view_1');
+      expect((adapter.last!.data as Map<String, dynamic>)['name'], 'Renamed');
+    });
+
+    test('delete -> DELETE /views/{id}', () async {
+      await views.delete('view_1');
+      expect(adapter.last!.method, 'DELETE');
+      expect(adapter.last!.path, '/views/view_1');
+    });
+
+    test('createQuery -> POST /views/{id}/queries', () async {
+      await views.createQuery('view_1');
+      expect(adapter.last!.method, 'POST');
+      expect(adapter.last!.path, '/views/view_1/queries');
+    });
+
+    test('retrieveQueryResults -> GET /views/{id}/queries/{queryId}', () async {
+      await views.retrieveQueryResults('view_1', 'q_1', pageSize: 25);
+      expect(adapter.last!.method, 'GET');
+      expect(adapter.last!.path, '/views/view_1/queries/q_1');
+      expect(adapter.last!.queryParameters['page_size'], 25);
+    });
+
+    test('deleteQuery -> DELETE /views/{id}/queries/{queryId}', () async {
+      await views.deleteQuery('view_1', 'q_1');
+      expect(adapter.last!.method, 'DELETE');
+      expect(adapter.last!.path, '/views/view_1/queries/q_1');
+    });
+  });
+}


### PR DESCRIPTION
## 概要

`ViewsService` のエンドポイント形状を公式仕様と照合した結果、**実装は正しい**ことが確定したため、形状を固定する回帰テストと検証済みリファレンスを追加します(本番コードの変更なし)。

Closes #41

## リサーチ結果(権威ある照合)

公式 notion-sdk-js(v5.12.0, API 2026-03-11)`src/api-endpoints/views.ts` で全エンドポイントを確認:

| 操作 | Method | Path |
|------|--------|------|
| list | `GET` | `/views`(`database_id` または `data_source_id`) |
| retrieve | `GET` | `/views/{id}` |
| create | `POST` | `/views` |
| update | `PATCH` | `/views/{id}` |
| delete | `DELETE` | `/views/{id}` |
| createQuery | `POST` | `/views/{id}/queries` |
| query results | `GET` | `/views/{id}/queries/{query_id}` |
| deleteQuery | `DELETE` | `/views/{id}/queries/{query_id}` |

→ パッケージの実装と**完全一致**。当初疑っていた `/databases/{id}/views` や `duplicate`/`properties`、単数形 `query` は**第三者要約の誤り**で、公式SDKには存在しません。

## 変更

- `test/views_service_test.dart`: 記録用 Dio アダプタで各メソッドの method + path + query/body を固定(回帰防止)。
- `doc/working-with-views.md`: 検証済みエンドポイント仕様を記録(`doc/` に views 仕様が無かったため補完)。

## テスト

`dart analyze --fatal-infos` クリーン / `dart format` クリーン / 全テストパス(357)。

🤖 リサーチに基づく自動メンテナンス PR です。

https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1)_