### PR TITLE
ci(release): fix non-fast-forward race in auto-patch-release workflow

### DIFF
--- a/.github/workflows/auto-patch-release.yml
+++ b/.github/workflows/auto-patch-release.yml
@@ -9,6 +9,13 @@ on:
 permissions:
   contents: write
 
+# Serialize release runs so concurrent merges don't race on the version bump
+# push (which previously failed with non-fast-forward errors). Queued runs are
+# not cancelled so every merged change still gets its own patch release.
+concurrency:
+  group: auto-patch-release
+  cancel-in-progress: false
+
 jobs:
   check-and-release:
     name: Check for Version Changes and Release
@@ -32,6 +39,14 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync to latest main
+        # actions/checkout pins the triggering commit. When several merges land
+        # close together, the version must be computed from (and pushed onto)
+        # the newest main, otherwise `git push` is rejected as non-fast-forward.
+        run: |
+          git fetch origin main
+          git checkout -B main origin/main
 
       - name: Get current version
         id: current_version


### PR DESCRIPTION
## 概要

「CIが落ちている」とご指摘の件を調査しました。

**結論: CI(テスト/解析/pana)は全て成功しており、コードは健全です。** 失敗しているのは別ワークフロー **「Auto Patch Release on Merge」** で、これは**既存の競合バグ**(2026-05-05の連続マージ時も同様に失敗)です。本PRでそれを修正します。

## 原因

`auto-patch-release.yml` はバージョンを上げて `git push origin main` しますが:

1. `actions/checkout` は**トリガー時点のコミット**を取得する。
2. 短時間に複数PRをマージすると、後発のリリース実行は古い main 上でバージョンを算出・コミットし、`git push origin main` が **`non-fast-forward`** で拒否される。
3. リリース実行間の**並行制御(concurrency)が無い**ため競合する。

実害: 今回の3マージでバージョンbumpは1回(1.0.2→**1.0.3**, コミット `9309211`)だけ成功し、残りは push 拒否で失敗(赤いX)になりました。コード・タグ・公開物の破損はありません。

## 修正

```yaml
concurrency:
  group: auto-patch-release
  cancel-in-progress: false   # 直列化(キャンセルせずキュー)
```

```yaml
- name: Sync to latest main
  run: |
    git fetch origin main
    git checkout -B main origin/main   # 最新mainからバージョン算出・push
```

- **直列化**: リリース実行を1つずつ処理し、並行競合を排除(各マージは引き続き個別のパッチリリースを取得)。
- **最新mainへ同期**: バージョンを最新 main から算出してコミット → push が必ず fast-forward に。

## 補足

- YAML 構文は検証済み。
- マージ後の push に対するリリース実行は**この修正版ワークフロー**で動作します(GitHub は push 対象コミットのワークフロー定義を使用するため自己修復的)。
- より堅牢にするなら人手の直接 push 対策として push 前 `git pull --rebase` の追加も可能ですが、観測された競合は本修正で解消します。

🤖 リサーチに基づく自動メンテナンス PR です。

https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGbXNKkPNDjpwwQQ6VAzz1)_